### PR TITLE
Add safety feature for testing algo changes

### DIFF
--- a/.github/workflows/run_jcb_basic_testing.yaml
+++ b/.github/workflows/run_jcb_basic_testing.yaml
@@ -52,6 +52,34 @@ jobs:
           echo "JCB_BRANCH=develop" >> $GITHUB_ENV
         fi
 
+    - name: Check for the branch name in the jcb-algorithms repo
+      run: |
+        BRANCH_NAME=${{ env.JCB_APP_BRANCH }}
+        if git ls-remote --heads https://github.com/NOAA-EMC/jcb-algorithms.git $BRANCH_NAME | grep -q "refs/heads/$BRANCH_NAME"; then
+          echo "Branch $BRANCH_NAME exists in jcb-algorithms repo."
+          echo "JCB_ALGO_BRANCH=$BRANCH_NAME" >> $GITHUB_ENV
+
+          # If the branch exists in jcb-algorithms repo but JCB_BRANCH is develop then we need to
+          # throw an error. This is not a safe situation. The developer should create a branch in
+          # the main jcb repo with the same name as the branch in the jcb-application repo.
+          # If there were branches in other apps to account for the changes in the algorithm repo
+          # they could not be tested here since the scipt is not clever enough to check for
+          # the existence of the branch being tested here in all the clients. The safest thing to do
+          # is simply create a branch with the same name (even if empty) in the main jcb repo. This
+          # will ensure the branches of the other applications are checked out by the init script.
+
+          if [ "${{ env.JCB_BRANCH }}" == "develop" ]; then
+            echo "Branch $BRANCH_NAME exists in jcb-algorithms repo but not in the main jcb repo. "
+            echo "Please create a branch with the same name (even if empty with no PR) in the main "
+            echo "jcb repo. This ensures safely checking all the clients that depend on the "
+            echo "jcb and jcb-algorithms repos with the changes being proposed."
+            exit 1
+          fi
+        else
+          echo "Branch $BRANCH_NAME does not exist in jcb repo. Using develop branch."
+          echo "JCB_ALGO_BRANCH=develop" >> $GITHUB_ENV
+        fi
+
     - name: Clone jcb repository
       run: |
         mkdir -p empty_hooks


### PR DESCRIPTION
When the JCB tests are being run (from anywhere) the code will clone the main JCB repo and when doing so it will look for the branch name of the PR. Then it will run a script to clone all the clients that are registered for testing as well as the algorithms repo. This script will use the branch name of the main JCB repo and if found for any clients clone that branch.

Now imagine this scenario: someone is making changes to their client (say gdas) and simultaneously making changes to jcb-algorithms. They might realize that they need to change another client to accommodate the algorithm changes so they make a branch with the same name in (say) rrfs. However if they do not have that branch in the main jcb repo there wouldn't exist a mechanism to check out the correct branch of jcb-algorithms and the other clients during the integration tests. We could put that kind of logic in the GitHub script but that would be complicated and have to propagate to every jcb repo.

The change in this code forces the user to make a branch of the main jcb repo if they have created the same branch in the jcb-algorithms branch and thus provide all the mechanisms for the scripts to check everything out properly.

The algorithms should really be part of JCB since they are generic and it would avoid the need to do this. But because of EE2 compliance we can't have YAMLs with source code, which is why they are in a separate repo. 