### PR TITLE
Updates to marine yamls to match v2 expt

### DIFF
--- a/observations/marine/adt_rads_all.yaml.j2
+++ b/observations/marine/adt_rads_all.yaml.j2
@@ -41,7 +41,7 @@
           variables: [GeoVaLs/mesoscale_representation_error,
                       ObsError/absoluteDynamicTopography]
           coefs: [0.2,
-                  2.0]
+                  10.0]
   - filter: Domain Check
     where:
     - variable: { name: GeoVaLs/sea_ice_area_fraction}

--- a/observations/marine/icec_abi_g16_l2.yaml.j2
+++ b/observations/marine/icec_abi_g16_l2.yaml.j2
@@ -43,3 +43,15 @@
     where:
     - variable: {name: GeoVaLs/distance_from_coast}
       minvalue: 100e3
+  - filter: Gaussian Thinning
+    horizontal_mesh: 25  #km
+    use_reduced_horizontal_grid: true
+    select_median: true
+    action:
+      name: reduce obs space
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: GeoVaLs/sea_surface_temperature}
+      maxvalue: -4.0

--- a/observations/marine/icec_amsr2_north.yaml.j2
+++ b/observations/marine/icec_amsr2_north.yaml.j2
@@ -43,3 +43,9 @@
     where:
     - variable: {name: GeoVaLs/distance_from_coast}
       minvalue: 100e3
+#  - filter: Gaussian Thinning
+#    horizontal_mesh: 25  #km
+#    use_reduced_horizontal_grid: true
+#    select_median: true
+#    action:
+#      name: reduce obs space

--- a/observations/marine/icec_amsr2_south.yaml.j2
+++ b/observations/marine/icec_amsr2_south.yaml.j2
@@ -43,3 +43,9 @@
     where:
     - variable: {name: GeoVaLs/distance_from_coast}
       minvalue: 100e3
+#  - filter: Gaussian Thinning
+#    horizontal_mesh: 25  #km
+#    use_reduced_horizontal_grid: true
+#    select_median: true
+#    action:
+#      name: reduce obs space

--- a/observations/marine/icec_amsu_mb_l2.yaml.j2
+++ b/observations/marine/icec_amsu_mb_l2.yaml.j2
@@ -43,3 +43,15 @@
     where:
     - variable: {name: GeoVaLs/distance_from_coast}
       minvalue: 100e3
+  - filter: Gaussian Thinning
+    horizontal_mesh: 25  #km
+    use_reduced_horizontal_grid: true
+    select_median: true
+    action:
+      name: reduce obs space
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: GeoVaLs/sea_surface_temperature}
+      maxvalue: -4.0

--- a/observations/marine/icec_atms_n20_l2.yaml.j2
+++ b/observations/marine/icec_atms_n20_l2.yaml.j2
@@ -43,3 +43,15 @@
     where:
     - variable: {name: GeoVaLs/distance_from_coast}
       minvalue: 100e3
+  - filter: Gaussian Thinning
+    horizontal_mesh: 25  #km
+    use_reduced_horizontal_grid: true
+    select_median: true
+    action:
+      name: reduce obs space
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: GeoVaLs/sea_surface_temperature}
+      maxvalue: -4.0

--- a/observations/marine/icec_atms_n21_l2.yaml.j2
+++ b/observations/marine/icec_atms_n21_l2.yaml.j2
@@ -43,3 +43,15 @@
     where:
     - variable: {name: GeoVaLs/distance_from_coast}
       minvalue: 100e3
+  - filter: Gaussian Thinning
+    horizontal_mesh: 25  #km
+    use_reduced_horizontal_grid: true
+    select_median: true
+    action:
+      name: reduce obs space
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: GeoVaLs/sea_surface_temperature}
+      maxvalue: -4.0

--- a/observations/marine/icec_atms_npp_l2.yaml.j2
+++ b/observations/marine/icec_atms_npp_l2.yaml.j2
@@ -43,3 +43,15 @@
     where:
     - variable: {name: GeoVaLs/distance_from_coast}
       minvalue: 100e3
+  - filter: Gaussian Thinning
+    horizontal_mesh: 25  #km
+    use_reduced_horizontal_grid: true
+    select_median: true
+    action:
+      name: reduce obs space
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: GeoVaLs/sea_surface_temperature}
+      maxvalue: -4.0

--- a/observations/marine/icec_gmi_gpm_l2.yaml.j2
+++ b/observations/marine/icec_gmi_gpm_l2.yaml.j2
@@ -43,3 +43,9 @@
     where:
     - variable: {name: GeoVaLs/distance_from_coast}
       minvalue: 100e3
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: GeoVaLs/sea_surface_temperature}
+      maxvalue: -4.0

--- a/observations/marine/icec_ssmis_f17_l2.yaml.j2
+++ b/observations/marine/icec_ssmis_f17_l2.yaml.j2
@@ -43,3 +43,15 @@
     where:
     - variable: {name: GeoVaLs/distance_from_coast}
       minvalue: 100e3
+  - filter: Gaussian Thinning
+    horizontal_mesh: 25  #km
+    use_reduced_horizontal_grid: true
+    select_median: true
+    action:
+      name: reduce obs space
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: GeoVaLs/sea_surface_temperature}
+      maxvalue: -4.0

--- a/observations/marine/icec_viirs_n20_l2_north.yaml.j2
+++ b/observations/marine/icec_viirs_n20_l2_north.yaml.j2
@@ -43,3 +43,15 @@
     where:
     - variable: {name: GeoVaLs/distance_from_coast}
       minvalue: 100e3
+  - filter: Gaussian Thinning
+    horizontal_mesh: 25  #km
+    use_reduced_horizontal_grid: true
+    select_median: true
+    action:
+      name: reduce obs space
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: GeoVaLs/sea_surface_temperature}
+      maxvalue: -4.0

--- a/observations/marine/icec_viirs_n20_l2_south.yaml.j2
+++ b/observations/marine/icec_viirs_n20_l2_south.yaml.j2
@@ -43,3 +43,15 @@
     where:
     - variable: {name: GeoVaLs/distance_from_coast}
       minvalue: 100e3
+  - filter: Gaussian Thinning
+    horizontal_mesh: 25  #km
+    use_reduced_horizontal_grid: true
+    select_median: true
+    action:
+      name: reduce obs space
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: GeoVaLs/sea_surface_temperature}
+      maxvalue: -4.0

--- a/observations/marine/sss_smap_l2.yaml.j2
+++ b/observations/marine/sss_smap_l2.yaml.j2
@@ -33,7 +33,8 @@
       name: passivate
     where:
     - variable: {name: GeoVaLs/sea_surface_temperature}
-      minvalue: 15.0
+#      minvalue: 15.0
+      maxvalue: -4.0
   ## Gaussian_Thinning is having problems with LETKF, try again later
   # - filter: Gaussian_Thinning
   #   horizontal_mesh:   25.0 #km

--- a/observations/marine/sss_smos_l2.yaml.j2
+++ b/observations/marine/sss_smos_l2.yaml.j2
@@ -33,7 +33,8 @@
       name: passivate
     where:
     - variable: {name: GeoVaLs/sea_surface_temperature}
-      minvalue: 15.0
+#      minvalue: 15.0
+      maxvalue: -4.0
   ## Gaussian_Thinning is having problems with LETKF, try again later
   # - filter: Gaussian_Thinning
   #   horizontal_mesh:   25.0 #km


### PR DESCRIPTION
This update to the marine yamls in jcb-gdas increases the obs error for ADT, adds a gaussian thinning filter and passivate filter for sea ice retrievals (except for AMSR2) and adds a passivate filter for SMAP/SMOS SSS retrievals.