### PR TITLE
update soil variables to be consistent with fv3-jedi changes

### DIFF
--- a/model/atmosphere/atmosphere_background.yaml.j2
+++ b/model/atmosphere/atmosphere_background.yaml.j2
@@ -1,10 +1,8 @@
 datapath: {{ atmosphere_background_path }}
 filetype: cube sphere history
 provider: ufs
-ufs soil nlev: 4
-ufs fields split by level: [smc,stc]
 datetime: "{{ atmosphere_background_time_iso }}"
 filenames: [ {{ atmosphere_variational_history_prefix }}cubed_sphere_grid_atmf006.nc, {{ atmosphere_variational_history_prefix }}cubed_sphere_grid_sfcf006.nc ]
 state variables: [ua,va,t,delp,ps,sphum,ice_wat,liq_wat,o3mr,hgtsfc,
-                  slmsk,sheleg,tmpsfc,vtype,stype,vfrac,stc,smc,snwdphMeters,
+                  slmsk,sheleg,tmpsfc,vtype,stype,vfrac,soilt1,soilw1,snwdphMeters,
                   u_srf,v_srf,f10m]

--- a/model/atmosphere/atmosphere_background_ensemble.yaml.j2
+++ b/model/atmosphere/atmosphere_background_ensemble.yaml.j2
@@ -4,10 +4,8 @@ members from template:
     datetime: '{{ atmosphere_background_time_iso }}'
     filetype: cube sphere history
     provider: ufs
-    ufs soil nlev: 4
-    ufs fields split by level: [smc,stc]
     state variables: [ua,va,t,delz,delp,ps,sphum,ice_wat,liq_wat,o3mr,hgtsfc,
-                     slmsk,sheleg,tmpsfc,vtype,stype,vfrac,stc,smc,snwdphMeters,
+                     slmsk,sheleg,tmpsfc,vtype,stype,vfrac,soilt1,soilw1,snwdphMeters,
                      u_srf,v_srf,f10m]
     datapath: {{ atmosphere_background_ensemble_path }}
     filename is datetime templated: true


### PR DESCRIPTION
When the GDASApp `sorc/fv3-jedi` hash is updated to [97e10d5](https://github.com/JCSDA-internal/fv3-jedi/commit/97e10d5addfe75debab7a6b5604e7a7443f00333) or a hash after this commit, it is necessary, at a minimum, to update soil variables in the following templates
```
model/atmosphere/atmosphere_background.yaml.j2
model/atmosphere/atmosphere_background_ensemble.yaml.j2
```
This PR is opened to update the soil variables in the above templates.

Resolves #49

**NOTE**: GDASApp PR [#1377](https://github.com/NOAA-EMC/GDASApp/pull/1377) requires this PR be merged into jcb-gdas `develop`.  Once this is done, the `parm/jcb-gdas` hash in [#1377](https://github.com/NOAA-EMC/GDASApp/pull/1377) should be updated to point at the new jcb-gdas `develop`.