### PR TITLE
Set channels without bias correction.

### DIFF
--- a/observations/atmosphere/amsua_n19.yaml.j2
+++ b/observations/atmosphere/amsua_n19.yaml.j2
@@ -34,6 +34,8 @@
   obs bias:
     input file: "{{atmosphere_obsbiasin_path}}/{{atmosphere_obsbiasin_prefix}}{{observation_from_jcb}}{{atmosphere_obsbiasin_suffix}}"
     output file: "{{atmosphere_obsbiasout_path}}/{{atmosphere_obsbiasout_prefix}}{{observation_from_jcb}}{{atmosphere_obsbiasout_suffix}}"
+    variables without bc: [brightnessTemperature]
+    channels: &{{observation_from_jcb}}_not_bias_corrected {{ get_satellite_variable(observation_from_jcb, "not_biascorrtd") }}
     variational bc:
       predictors:
       - name: constant

--- a/observations/atmosphere/atms_n20.yaml.j2
+++ b/observations/atmosphere/atms_n20.yaml.j2
@@ -37,6 +37,8 @@
   obs bias:
     input file: "{{atmosphere_obsbiasin_path}}/{{atmosphere_obsbiasin_prefix}}{{observation_from_jcb}}{{atmosphere_obsbiasin_suffix}}"
     output file: "{{atmosphere_obsbiasout_path}}/{{atmosphere_obsbiasout_prefix}}{{observation_from_jcb}}{{atmosphere_obsbiasout_suffix}}"
+    variables without bc: [brightnessTemperature]
+    channels: &{{observation_from_jcb}}_not_bias_corrected {{ get_satellite_variable(observation_from_jcb, "not_biascorrtd") }}
     variational bc:
       predictors:
       - name: constant

--- a/observations/atmosphere/atms_npp.yaml.j2
+++ b/observations/atmosphere/atms_npp.yaml.j2
@@ -37,6 +37,8 @@
   obs bias:
     input file: "{{atmosphere_obsbiasin_path}}/{{atmosphere_obsbiasin_prefix}}{{observation_from_jcb}}{{atmosphere_obsbiasin_suffix}}"
     output file: "{{atmosphere_obsbiasout_path}}/{{atmosphere_obsbiasout_prefix}}{{observation_from_jcb}}{{atmosphere_obsbiasout_suffix}}"
+    variables without bc: [brightnessTemperature]
+    channels: &{{observation_from_jcb}}_not_bias_corrected {{ get_satellite_variable(observation_from_jcb, "not_biascorrtd") }}
     variational bc:
       predictors:
       - name: constant

--- a/observations/atmosphere/cris-fsr_n20.yaml.j2
+++ b/observations/atmosphere/cris-fsr_n20.yaml.j2
@@ -34,6 +34,8 @@
   obs bias:
     input file: "{{atmosphere_obsbiasin_path}}/{{atmosphere_obsbiasin_prefix}}{{observation_from_jcb}}{{atmosphere_obsbiasin_suffix}}"
     output file: "{{atmosphere_obsbiasout_path}}/{{atmosphere_obsbiasout_prefix}}{{observation_from_jcb}}{{atmosphere_obsbiasout_suffix}}"
+    variables without bc: [brightnessTemperature]
+    channels: &{{observation_from_jcb}}_not_bias_corrected {{ get_satellite_variable(observation_from_jcb, "not_biascorrtd") }}
     variational bc:
       predictors:
       - name: constant


### PR DESCRIPTION
Render channels for which bias correction is turned off from the chronicle tables. AMSU-A channel 14 and ATMS channel 15 are not bias corrected in GSI.

When all channels are bias corrected, set '-999' in the list of channels without bias correction. That makes UFO conduct bias correction for all channels. An example is added in cris-fsr_n20.yaml.j2.

It is dependent on the JCB PR https://github.com/NOAA-EMC/jcb/pull/15. 