### PR TITLE
Turn shuffle option on in soca -> cice.

### DIFF
--- a/algorithm/marine/soca_2cice_global.yaml.j2
+++ b/algorithm/marine/soca_2cice_global.yaml.j2
@@ -9,15 +9,15 @@ output geometry:
 variable change:
   variable change name: Soca2Cice
   arctic:
-    seaice edge: 0.8
-    shuffle: false
+    seaice edge: 0.4
+    shuffle: true
     rescale prior:
       rescale: true
       min hice: 0.5
       min hsno: 0.1
   antarctic:
-    seaice edge: 0.9
-    shuffle: false  # seg. fault when true
+    seaice edge: 0.4
+    shuffle: true
     rescale prior:
       rescale: true
       min hice: 0.5


### PR DESCRIPTION
This turns on shuffle option in soca -> cice and changes `seaice edge` to 40%.
For all background ice concentrations < `seaice edge` when shuffle is on, the code finds a nearest background point whose total ice concentration is closest to the soca analysis total ice concentration, and copies that background ice profile as the new analysis at the current point. For all background ice concentrations > `seaice edge` ice concentrations are rescaled, and some ice fields recomputed.

Some results from a first cycle of high res experiment:
Background:
![ice_bg](https://github.com/user-attachments/assets/645f8826-9cad-4987-8fc4-7cf240ee5b15)
soca analysis (no postprocessing; I am cutting off values outside of [0, 1] when plotting):
![ice_an_soca](https://github.com/user-attachments/assets/e52651ea-e30f-4091-bf88-2becb8ee6c4c)
analysis after Soca2Cice on develop (where `shuffle` is off, and `seaice edge` for the arctic is 0.8) As expected, the analysis looks like background for ice concentrations < 0.8
![ice_an_soca2cice_noshuffle](https://github.com/user-attachments/assets/2ba397d5-14a9-451f-bbeb-b5bae4e3c20d)
analysis after Soca2Cice in this branch (`shuffle` is on, `seaice edge` is set to 0.4). Note that these results are with https://github.com/JCSDA-internal/soca/pull/1108
![ice_an_soca2cice_shuffle_bugfix_edge40](https://github.com/user-attachments/assets/4b45072c-1ea3-47f6-a488-62f7720bd1fa)

This branch can be merged in develop regardless of https://github.com/JCSDA-internal/soca/pull/1108, since gdasapp soca hash already includes the bugfix that allows `shuffle` to be turned on. However, I would recommend running experiments that include https://github.com/JCSDA-internal/soca/pull/1108 which further improves on shuffle.

I ran C384mx025_3DVarAOWCDA for 2 cycles with this setup, and forecasts succeeded (cice was OK with these analyses). We'll do better evaluation when we run the next marine candidate experiment.