### PR TITLE
Add GNSSRO yaml files

### DIFF
--- a/observations/atmosphere/gnssro_cosmic2.yaml.j2
+++ b/observations/atmosphere/gnssro_cosmic2.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam
+    name: gnssrobndnbam_cosmic2
     obsdatain:
       engine:
         type: H5File

--- a/observations/atmosphere/gnssro_cosmic2.yaml.j2
+++ b/observations/atmosphere/gnssro_cosmic2.yaml.j2
@@ -1,0 +1,128 @@
+-
+
+  # Observation Space (I/O)
+  # -----------------------
+  obs space:
+    name: gnssrobndnbam
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdatain_path}}/{{atmosphere_obsdatain_prefix}}{{observation_from_jcb}}{{atmosphere_obsdatain_suffix}}" 
+      obsgrouping:
+        group variables: [ 'sequenceNumber' ]
+        sort variable: 'impactHeightRO'
+        sort order: 'ascending'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"        
+    simulated variables: [bendingAngle]
+
+  # Observation Operator
+  # --------------------
+  obs operator:
+    name: GnssroBndNBAM
+    obs options:
+      use_compress: 1
+      sr_steps: 2
+      vertlayer: full
+      super_ref_qc: NBAM
+      output_diags: true
+
+  # Observation Filters (QC)
+  # ------------------------
+  obs filters:
+  # Apply gross check using pccf
+  # Step 0-A: Create Diagnostic Flags 
+  # Diagnostic flag for pccf
+  - filter: Create Diagnostic Flags
+    filter variables:  
+    - name: bendingAngle 
+    flags:
+    - name: pccfCheckReject
+      initial value: false 
+      force reinitialization: true
+  
+  # Diagnostic flag for qfro
+  - filter: Create Diagnostic Flags
+    filter variables:
+    - name: bendingAngle
+    flags:
+    - name: qfroCheckReject
+      initial value: false
+      force reinitialization: true
+  
+  # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
+  - filter: Bounds Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/satelliteIdentifier
+      is_in: 265-269,750-755,44,786,820,825
+    test variables:
+    - name: MetaData/pccf
+    minvalue: 0.1
+    maxvalue: 100.1
+    actions:
+    - name: set
+      flag: pccfCheckReject
+    - name: reject
+  
+  # Step 0-B: qfro Check - good: 0, reject: 1
+  #- filter: Bounds Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  where:
+  #  - variable:
+  #      name: MetaData/satelliteIdentifier
+  #    is_in: 3-5,421,440,821
+  #  test variables:
+  #  - name: MetaData/qualityFlags
+  #  minvalue: -0.1
+  #  maxvalue: 0.9
+  #  actions:
+  #  - name: set
+  #    flag: qfroCheckReject
+  #  - name: reject
+  
+  #1. gpstop
+  - filter: Domain Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/impactHeightRO
+      minvalue: 0
+      maxvalue: 55000.1
+    action:
+      name: reject
+  #2. Background check
+  #- filter: Background Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  threshold: 10
+  #  action:
+  #    name: reject
+  #  defer to post: true
+  #3. RONBAM cut off check
+  - filter: Background Check RONBAM
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: reject
+    defer to post: true
+  #4. assign obs error 
+  - filter: ROobserror
+    filter variables:
+    - name: bendingAngle
+    errmodel: NBAM
+    defer to post: true
+  #5. Obs error inflate
+  - filter: Perform Action
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: RONBAMErrInflate
+    defer to post: true
+  # --------------------------------

--- a/observations/atmosphere/gnssro_cosmic2.yaml.j2
+++ b/observations/atmosphere/gnssro_cosmic2.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam_cosmic2
+    name: gnssrobndnbam
     obsdatain:
       engine:
         type: H5File
@@ -69,23 +69,6 @@
       flag: pccfCheckReject
     - name: reject
   
-  # Step 0-B: qfro Check - good: 0, reject: 1
-  #- filter: Bounds Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  where:
-  #  - variable:
-  #      name: MetaData/satelliteIdentifier
-  #    is_in: 3-5,421,440,821
-  #  test variables:
-  #  - name: MetaData/qualityFlags
-  #  minvalue: -0.1
-  #  maxvalue: 0.9
-  #  actions:
-  #  - name: set
-  #    flag: qfroCheckReject
-  #  - name: reject
-  
   #1. gpstop
   - filter: Domain Check
     filter variables:
@@ -97,14 +80,6 @@
       maxvalue: 55000.1
     action:
       name: reject
-  #2. Background check
-  #- filter: Background Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  threshold: 10
-  #  action:
-  #    name: reject
-  #  defer to post: true
   #3. RONBAM cut off check
   - filter: Background Check RONBAM
     filter variables:

--- a/observations/atmosphere/gnssro_cosmic2.yaml.j2
+++ b/observations/atmosphere/gnssro_cosmic2.yaml.j2
@@ -43,15 +43,6 @@
       initial value: false 
       force reinitialization: true
   
-  # Diagnostic flag for qfro
-  - filter: Create Diagnostic Flags
-    filter variables:
-    - name: bendingAngle
-    flags:
-    - name: qfroCheckReject
-      initial value: false
-      force reinitialization: true
-  
   # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
   - filter: Bounds Check
     filter variables:

--- a/observations/atmosphere/gnssro_geoopt.yaml.j2
+++ b/observations/atmosphere/gnssro_geoopt.yaml.j2
@@ -1,0 +1,130 @@
+-
+
+  # Observation Space (I/O)
+  # -----------------------
+  obs space:
+    name: gnssrobndnbam
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdatain_path}}/{{atmosphere_obsdatain_prefix}}{{observation_from_jcb}}{{atmosphere_obsdatain_suffix}}" 
+      obsgrouping:
+        group variables: [ 'sequenceNumber' ]
+        sort variable: 'impactHeightRO'
+        sort order: 'ascending'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"        
+    simulated variables: [bendingAngle]
+
+  # Observation Operator
+  # --------------------
+  obs operator:
+    name: GnssroBndNBAM
+    obs options:
+      use_compress: 1
+      sr_steps: 2
+      vertlayer: full
+      super_ref_qc: NBAM
+      output_diags: true
+
+  # Observation Filters (QC)
+  # ------------------------
+  obs filters:
+  # Apply gross check using pccf
+  # Step 0-A: Create Diagnostic Flags 
+  # Diagnostic flag for pccf
+  - filter: Create Diagnostic Flags
+    filter variables:  
+    - name: bendingAngle 
+    flags:
+    - name: pccfCheckReject
+      initial value: false 
+      force reinitialization: true
+  
+  # Diagnostic flag for qfro
+  - filter: Create Diagnostic Flags
+    filter variables:
+    - name: bendingAngle
+    flags:
+    - name: qfroCheckReject
+      initial value: false
+      force reinitialization: true
+  
+  # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
+  - filter: Bounds Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/satelliteIdentifier
+      is_in: 265-269,750-755,44,786,820,825
+    test variables:
+    - name: MetaData/pccf
+    minvalue: 0.1
+    maxvalue: 100.1
+    actions:
+    - name: set
+      flag: pccfCheckReject
+    - name: reject
+  
+  # Step 0-B: qfro Check - good: 0, reject: 1
+  #- filter: Bounds Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  where:
+  #  - variable:
+  #      name: MetaData/satelliteIdentifier
+  #    is_in: 3-5,421,440,821
+  #  test variables:
+  #  - name: MetaData/qualityFlags
+  #  minvalue: -0.1
+  #  maxvalue: 0.9
+  #  actions:
+  #  - name: set
+  #    flag: qfroCheckReject
+  #  - name: reject
+  
+  #1. commgpstop
+  - filter: Bounds Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/satelliteIdentifier
+      is_in: 265,266,267,268,269
+    test variables:
+    - name: MetaData/impactHeightRO
+    maxvalue: 45000.1
+    action:
+      name: reject
+  #2. Background check
+  #- filter: Background Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  threshold: 10
+  #  action:
+  #    name: reject
+  #  defer to post: true
+  #3. RONBAM cut off check
+  - filter: Background Check RONBAM
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: reject
+    defer to post: true
+  #4. assign obs error 
+  - filter: ROobserror
+    filter variables:
+    - name: bendingAngle
+    errmodel: NBAM
+    defer to post: true
+  #5. Obs error inflate
+  - filter: Perform Action
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: RONBAMErrInflate
+    defer to post: true
+  # --------------------------------

--- a/observations/atmosphere/gnssro_geoopt.yaml.j2
+++ b/observations/atmosphere/gnssro_geoopt.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam_geoopt
+    name: gnssrobndnbam
     obsdatain:
       engine:
         type: H5File
@@ -69,23 +69,6 @@
       flag: pccfCheckReject
     - name: reject
   
-  # Step 0-B: qfro Check - good: 0, reject: 1
-  #- filter: Bounds Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  where:
-  #  - variable:
-  #      name: MetaData/satelliteIdentifier
-  #    is_in: 3-5,421,440,821
-  #  test variables:
-  #  - name: MetaData/qualityFlags
-  #  minvalue: -0.1
-  #  maxvalue: 0.9
-  #  actions:
-  #  - name: set
-  #    flag: qfroCheckReject
-  #  - name: reject
-  
   #1. commgpstop
   - filter: Bounds Check
     filter variables:
@@ -99,14 +82,6 @@
     maxvalue: 45000.1
     action:
       name: reject
-  #2. Background check
-  #- filter: Background Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  threshold: 10
-  #  action:
-  #    name: reject
-  #  defer to post: true
   #3. RONBAM cut off check
   - filter: Background Check RONBAM
     filter variables:

--- a/observations/atmosphere/gnssro_geoopt.yaml.j2
+++ b/observations/atmosphere/gnssro_geoopt.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam
+    name: gnssrobndnbam_geoopt
     obsdatain:
       engine:
         type: H5File

--- a/observations/atmosphere/gnssro_geoopt.yaml.j2
+++ b/observations/atmosphere/gnssro_geoopt.yaml.j2
@@ -43,15 +43,6 @@
       initial value: false 
       force reinitialization: true
   
-  # Diagnostic flag for qfro
-  - filter: Create Diagnostic Flags
-    filter variables:
-    - name: bendingAngle
-    flags:
-    - name: qfroCheckReject
-      initial value: false
-      force reinitialization: true
-  
   # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
   - filter: Bounds Check
     filter variables:

--- a/observations/atmosphere/gnssro_grace.yaml.j2
+++ b/observations/atmosphere/gnssro_grace.yaml.j2
@@ -1,0 +1,128 @@
+-
+
+  # Observation Space (I/O)
+  # -----------------------
+  obs space:
+    name: gnssrobndnbam
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdatain_path}}/{{atmosphere_obsdatain_prefix}}{{observation_from_jcb}}{{atmosphere_obsdatain_suffix}}" 
+      obsgrouping:
+        group variables: [ 'sequenceNumber' ]
+        sort variable: 'impactHeightRO'
+        sort order: 'ascending'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"        
+    simulated variables: [bendingAngle]
+
+  # Observation Operator
+  # --------------------
+  obs operator:
+    name: GnssroBndNBAM
+    obs options:
+      use_compress: 1
+      sr_steps: 2
+      vertlayer: full
+      super_ref_qc: NBAM
+      output_diags: true
+
+  # Observation Filters (QC)
+  # ------------------------
+  obs filters:
+  # Apply gross check using pccf
+  # Step 0-A: Create Diagnostic Flags 
+  # Diagnostic flag for pccf
+  - filter: Create Diagnostic Flags
+    filter variables:  
+    - name: bendingAngle 
+    flags:
+    - name: pccfCheckReject
+      initial value: false 
+      force reinitialization: true
+  
+  # Diagnostic flag for qfro
+  - filter: Create Diagnostic Flags
+    filter variables:
+    - name: bendingAngle
+    flags:
+    - name: qfroCheckReject
+      initial value: false
+      force reinitialization: true
+  
+  # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
+  - filter: Bounds Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/satelliteIdentifier
+      is_in: 265-269,750-755,44,786,820,825
+    test variables:
+    - name: MetaData/pccf
+    minvalue: 0.1
+    maxvalue: 100.1
+    actions:
+    - name: set
+      flag: pccfCheckReject
+    - name: reject
+  
+  # Step 0-B: qfro Check - good: 0, reject: 1
+  #- filter: Bounds Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  where:
+  #  - variable:
+  #      name: MetaData/satelliteIdentifier
+  #    is_in: 3-5,421,440,821
+  #  test variables:
+  #  - name: MetaData/qualityFlags
+  #  minvalue: -0.1
+  #  maxvalue: 0.9
+  #  actions:
+  #  - name: set
+  #    flag: qfroCheckReject
+  #  - name: reject
+  
+  #1. gpstop
+  - filter: Domain Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/impactHeightRO
+      minvalue: 0
+      maxvalue: 55000.1
+    action:
+      name: reject
+  #2. Background check
+  #- filter: Background Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  threshold: 10
+  #  action:
+  #    name: reject
+  #  defer to post: true
+  #3. RONBAM cut off check
+  - filter: Background Check RONBAM
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: reject
+    defer to post: true
+  #4. assign obs error 
+  - filter: ROobserror
+    filter variables:
+    - name: bendingAngle
+    errmodel: NBAM
+    defer to post: true
+  #5. Obs error inflate
+  - filter: Perform Action
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: RONBAMErrInflate
+    defer to post: true
+  # --------------------------------

--- a/observations/atmosphere/gnssro_grace.yaml.j2
+++ b/observations/atmosphere/gnssro_grace.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam
+    name: gnssrobndnbam_grace
     obsdatain:
       engine:
         type: H5File

--- a/observations/atmosphere/gnssro_grace.yaml.j2
+++ b/observations/atmosphere/gnssro_grace.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam_grace
+    name: gnssrobndnbam
     obsdatain:
       engine:
         type: H5File
@@ -69,23 +69,6 @@
       flag: pccfCheckReject
     - name: reject
   
-  # Step 0-B: qfro Check - good: 0, reject: 1
-  #- filter: Bounds Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  where:
-  #  - variable:
-  #      name: MetaData/satelliteIdentifier
-  #    is_in: 3-5,421,440,821
-  #  test variables:
-  #  - name: MetaData/qualityFlags
-  #  minvalue: -0.1
-  #  maxvalue: 0.9
-  #  actions:
-  #  - name: set
-  #    flag: qfroCheckReject
-  #  - name: reject
-  
   #1. gpstop
   - filter: Domain Check
     filter variables:
@@ -97,14 +80,6 @@
       maxvalue: 55000.1
     action:
       name: reject
-  #2. Background check
-  #- filter: Background Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  threshold: 10
-  #  action:
-  #    name: reject
-  #  defer to post: true
   #3. RONBAM cut off check
   - filter: Background Check RONBAM
     filter variables:

--- a/observations/atmosphere/gnssro_grace.yaml.j2
+++ b/observations/atmosphere/gnssro_grace.yaml.j2
@@ -43,15 +43,6 @@
       initial value: false 
       force reinitialization: true
   
-  # Diagnostic flag for qfro
-  - filter: Create Diagnostic Flags
-    filter variables:
-    - name: bendingAngle
-    flags:
-    - name: qfroCheckReject
-      initial value: false
-      force reinitialization: true
-  
   # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
   - filter: Bounds Check
     filter variables:

--- a/observations/atmosphere/gnssro_k5.yaml.j2
+++ b/observations/atmosphere/gnssro_k5.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam_k5
+    name: gnssrobndnbam
     obsdatain:
       engine:
         type: H5File
@@ -69,23 +69,6 @@
       flag: pccfCheckReject
     - name: reject
   
-  # Step 0-B: qfro Check - good: 0, reject: 1
-  #- filter: Bounds Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  where:
-  #  - variable:
-  #      name: MetaData/satelliteIdentifier
-  #    is_in: 3-5,421,440,821
-  #  test variables:
-  #  - name: MetaData/qualityFlags
-  #  minvalue: -0.1
-  #  maxvalue: 0.9
-  #  actions:
-  #  - name: set
-  #    flag: qfroCheckReject
-  #  - name: reject
-  
   #1. gpstop
   - filter: Domain Check
     filter variables:
@@ -97,14 +80,6 @@
       maxvalue: 55000.1
     action:
       name: reject
-  #2. Background check
-  #- filter: Background Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  threshold: 10
-  #  action:
-  #    name: reject
-  #  defer to post: true
   #3. RONBAM cut off check
   - filter: Background Check RONBAM
     filter variables:

--- a/observations/atmosphere/gnssro_k5.yaml.j2
+++ b/observations/atmosphere/gnssro_k5.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam
+    name: gnssrobndnbam_k5
     obsdatain:
       engine:
         type: H5File

--- a/observations/atmosphere/gnssro_k5.yaml.j2
+++ b/observations/atmosphere/gnssro_k5.yaml.j2
@@ -1,0 +1,128 @@
+-
+
+  # Observation Space (I/O)
+  # -----------------------
+  obs space:
+    name: gnssrobndnbam
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdatain_path}}/{{atmosphere_obsdatain_prefix}}{{observation_from_jcb}}{{atmosphere_obsdatain_suffix}}" 
+      obsgrouping:
+        group variables: [ 'sequenceNumber' ]
+        sort variable: 'impactHeightRO'
+        sort order: 'ascending'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"        
+    simulated variables: [bendingAngle]
+
+  # Observation Operator
+  # --------------------
+  obs operator:
+    name: GnssroBndNBAM
+    obs options:
+      use_compress: 1
+      sr_steps: 2
+      vertlayer: full
+      super_ref_qc: NBAM
+      output_diags: true
+
+  # Observation Filters (QC)
+  # ------------------------
+  obs filters:
+  # Apply gross check using pccf
+  # Step 0-A: Create Diagnostic Flags 
+  # Diagnostic flag for pccf
+  - filter: Create Diagnostic Flags
+    filter variables:  
+    - name: bendingAngle 
+    flags:
+    - name: pccfCheckReject
+      initial value: false 
+      force reinitialization: true
+  
+  # Diagnostic flag for qfro
+  - filter: Create Diagnostic Flags
+    filter variables:
+    - name: bendingAngle
+    flags:
+    - name: qfroCheckReject
+      initial value: false
+      force reinitialization: true
+  
+  # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
+  - filter: Bounds Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/satelliteIdentifier
+      is_in: 265-269,750-755,44,786,820,825
+    test variables:
+    - name: MetaData/pccf
+    minvalue: 0.1
+    maxvalue: 100.1
+    actions:
+    - name: set
+      flag: pccfCheckReject
+    - name: reject
+  
+  # Step 0-B: qfro Check - good: 0, reject: 1
+  #- filter: Bounds Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  where:
+  #  - variable:
+  #      name: MetaData/satelliteIdentifier
+  #    is_in: 3-5,421,440,821
+  #  test variables:
+  #  - name: MetaData/qualityFlags
+  #  minvalue: -0.1
+  #  maxvalue: 0.9
+  #  actions:
+  #  - name: set
+  #    flag: qfroCheckReject
+  #  - name: reject
+  
+  #1. gpstop
+  - filter: Domain Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/impactHeightRO
+      minvalue: 0
+      maxvalue: 55000.1
+    action:
+      name: reject
+  #2. Background check
+  #- filter: Background Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  threshold: 10
+  #  action:
+  #    name: reject
+  #  defer to post: true
+  #3. RONBAM cut off check
+  - filter: Background Check RONBAM
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: reject
+    defer to post: true
+  #4. assign obs error 
+  - filter: ROobserror
+    filter variables:
+    - name: bendingAngle
+    errmodel: NBAM
+    defer to post: true
+  #5. Obs error inflate
+  - filter: Perform Action
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: RONBAMErrInflate
+    defer to post: true
+  # --------------------------------

--- a/observations/atmosphere/gnssro_k5.yaml.j2
+++ b/observations/atmosphere/gnssro_k5.yaml.j2
@@ -43,15 +43,6 @@
       initial value: false 
       force reinitialization: true
   
-  # Diagnostic flag for qfro
-  - filter: Create Diagnostic Flags
-    filter variables:
-    - name: bendingAngle
-    flags:
-    - name: qfroCheckReject
-      initial value: false
-      force reinitialization: true
-  
   # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
   - filter: Bounds Check
     filter variables:

--- a/observations/atmosphere/gnssro_metop.yaml.j2
+++ b/observations/atmosphere/gnssro_metop.yaml.j2
@@ -32,7 +32,7 @@
   # Observation Filters (QC)
   # ------------------------
   obs filters:
-  # Apply gross check using pccf
+  # Apply gross check using qfro
   # Step 0-A: Create Diagnostic Flags 
   # Diagnostic flag for qfro
   - filter: Create Diagnostic Flags

--- a/observations/atmosphere/gnssro_metop.yaml.j2
+++ b/observations/atmosphere/gnssro_metop.yaml.j2
@@ -34,15 +34,6 @@
   obs filters:
   # Apply gross check using pccf
   # Step 0-A: Create Diagnostic Flags 
-  # Diagnostic flag for pccf
-  - filter: Create Diagnostic Flags
-    filter variables:  
-    - name: bendingAngle 
-    flags:
-    - name: pccfCheckReject
-      initial value: false 
-      force reinitialization: true
-  
   # Diagnostic flag for qfro
   - filter: Create Diagnostic Flags
     filter variables:

--- a/observations/atmosphere/gnssro_metop.yaml.j2
+++ b/observations/atmosphere/gnssro_metop.yaml.j2
@@ -1,0 +1,141 @@
+-
+
+  # Observation Space (I/O)
+  # -----------------------
+  obs space:
+    name: gnssrobndnbam
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdatain_path}}/{{atmosphere_obsdatain_prefix}}{{observation_from_jcb}}{{atmosphere_obsdatain_suffix}}" 
+      obsgrouping:
+        group variables: [ 'sequenceNumber' ]
+        sort variable: 'impactHeightRO'
+        sort order: 'ascending'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"        
+    simulated variables: [bendingAngle]
+
+  # Observation Operator
+  # --------------------
+  obs operator:
+    name: GnssroBndNBAM
+    obs options:
+      use_compress: 1
+      sr_steps: 2
+      vertlayer: full
+      super_ref_qc: NBAM
+      output_diags: true
+
+  # Observation Filters (QC)
+  # ------------------------
+  obs filters:
+  # Apply gross check using pccf
+  # Step 0-A: Create Diagnostic Flags 
+  # Diagnostic flag for pccf
+  - filter: Create Diagnostic Flags
+    filter variables:  
+    - name: bendingAngle 
+    flags:
+    - name: pccfCheckReject
+      initial value: false 
+      force reinitialization: true
+  
+  # Diagnostic flag for qfro
+  - filter: Create Diagnostic Flags
+    filter variables:
+    - name: bendingAngle
+    flags:
+    - name: qfroCheckReject
+      initial value: false
+      force reinitialization: true
+  
+  # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
+  #- filter: Bounds Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  where:
+  #  - variable:
+  #      name: MetaData/satelliteIdentifier
+  #    is_in: 265-269,750-755,44,786,820,825
+  #  test variables:
+  #  - name: MetaData/pccf
+  #  minvalue: 0.1
+  #  maxvalue: 100.1
+  #  actions:
+  #  - name: set
+  #    flag: pccfCheckReject
+  #  - name: reject
+  
+  # Step 0-B: qfro Check - good: 0, reject: 1
+  - filter: Bounds Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/satelliteIdentifier
+      is_in: 3-5,421,440,821
+    test variables:
+    - name: MetaData/qualityFlags
+    minvalue: -0.1
+    maxvalue: 0.9
+    actions:
+    - name: set
+      flag: qfroCheckReject
+    - name: reject
+  
+  #1. gpstop
+  - filter: Domain Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/impactHeightRO
+      minvalue: 0
+      maxvalue: 55000.1
+    action:
+      name: reject
+  #2. Background check
+  #- filter: Background Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  threshold: 10
+  #  action:
+  #    name: reject
+  #  defer to post: true
+  #2. metop below 8 km
+  - filter: Bounds Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/satelliteIdentifier
+      is_in: 3-5
+    test variables:
+    - name: MetaData/impactHeightRO
+    minvalue: 8000.1
+    action:
+      name: reject
+  #3. RONBAM cut off check
+  - filter: Background Check RONBAM
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: reject
+    defer to post: true
+  #4. assign obs error 
+  - filter: ROobserror
+    filter variables:
+    - name: bendingAngle
+    errmodel: NBAM
+    defer to post: true
+  #5. Obs error inflate
+  - filter: Perform Action
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: RONBAMErrInflate
+    defer to post: true
+  # --------------------------------

--- a/observations/atmosphere/gnssro_metop.yaml.j2
+++ b/observations/atmosphere/gnssro_metop.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam_metop
+    name: gnssrobndnbam
     obsdatain:
       engine:
         type: H5File
@@ -52,23 +52,6 @@
       initial value: false
       force reinitialization: true
   
-  # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
-  #- filter: Bounds Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  where:
-  #  - variable:
-  #      name: MetaData/satelliteIdentifier
-  #    is_in: 265-269,750-755,44,786,820,825
-  #  test variables:
-  #  - name: MetaData/pccf
-  #  minvalue: 0.1
-  #  maxvalue: 100.1
-  #  actions:
-  #  - name: set
-  #    flag: pccfCheckReject
-  #  - name: reject
-  
   # Step 0-B: qfro Check - good: 0, reject: 1
   - filter: Bounds Check
     filter variables:
@@ -97,14 +80,6 @@
       maxvalue: 55000.1
     action:
       name: reject
-  #2. Background check
-  #- filter: Background Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  threshold: 10
-  #  action:
-  #    name: reject
-  #  defer to post: true
   #2. metop below 8 km
   - filter: Bounds Check
     filter variables:

--- a/observations/atmosphere/gnssro_metop.yaml.j2
+++ b/observations/atmosphere/gnssro_metop.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam
+    name: gnssrobndnbam_metop
     obsdatain:
       engine:
         type: H5File

--- a/observations/atmosphere/gnssro_paz.yaml.j2
+++ b/observations/atmosphere/gnssro_paz.yaml.j2
@@ -1,0 +1,128 @@
+-
+
+  # Observation Space (I/O)
+  # -----------------------
+  obs space:
+    name: gnssrobndnbam
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdatain_path}}/{{atmosphere_obsdatain_prefix}}{{observation_from_jcb}}{{atmosphere_obsdatain_suffix}}" 
+      obsgrouping:
+        group variables: [ 'sequenceNumber' ]
+        sort variable: 'impactHeightRO'
+        sort order: 'ascending'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"        
+    simulated variables: [bendingAngle]
+
+  # Observation Operator
+  # --------------------
+  obs operator:
+    name: GnssroBndNBAM
+    obs options:
+      use_compress: 1
+      sr_steps: 2
+      vertlayer: full
+      super_ref_qc: NBAM
+      output_diags: true
+
+  # Observation Filters (QC)
+  # ------------------------
+  obs filters:
+  # Apply gross check using pccf
+  # Step 0-A: Create Diagnostic Flags 
+  # Diagnostic flag for pccf
+  - filter: Create Diagnostic Flags
+    filter variables:  
+    - name: bendingAngle 
+    flags:
+    - name: pccfCheckReject
+      initial value: false 
+      force reinitialization: true
+  
+  # Diagnostic flag for qfro
+  - filter: Create Diagnostic Flags
+    filter variables:
+    - name: bendingAngle
+    flags:
+    - name: qfroCheckReject
+      initial value: false
+      force reinitialization: true
+  
+  # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
+  - filter: Bounds Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/satelliteIdentifier
+      is_in: 265-269,750-755,44,786,820,825
+    test variables:
+    - name: MetaData/pccf
+    minvalue: 0.1
+    maxvalue: 100.1
+    actions:
+    - name: set
+      flag: pccfCheckReject
+    - name: reject
+  
+  # Step 0-B: qfro Check - good: 0, reject: 1
+  #- filter: Bounds Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  where:
+  #  - variable:
+  #      name: MetaData/satelliteIdentifier
+  #    is_in: 3-5,421,440,821
+  #  test variables:
+  #  - name: MetaData/qualityFlags
+  #  minvalue: -0.1
+  #  maxvalue: 0.9
+  #  actions:
+  #  - name: set
+  #    flag: qfroCheckReject
+  #  - name: reject
+  
+  #1. gpstop
+  - filter: Domain Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/impactHeightRO
+      minvalue: 0
+      maxvalue: 55000.1
+    action:
+      name: reject
+  #2. Background check
+  #- filter: Background Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  threshold: 10
+  #  action:
+  #    name: reject
+  #  defer to post: true
+  #3. RONBAM cut off check
+  - filter: Background Check RONBAM
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: reject
+    defer to post: true
+  #4. assign obs error 
+  - filter: ROobserror
+    filter variables:
+    - name: bendingAngle
+    errmodel: NBAM
+    defer to post: true
+  #5. Obs error inflate
+  - filter: Perform Action
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: RONBAMErrInflate
+    defer to post: true
+  # --------------------------------

--- a/observations/atmosphere/gnssro_paz.yaml.j2
+++ b/observations/atmosphere/gnssro_paz.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam_paz
+    name: gnssrobndnbam
     obsdatain:
       engine:
         type: H5File
@@ -69,23 +69,6 @@
       flag: pccfCheckReject
     - name: reject
   
-  # Step 0-B: qfro Check - good: 0, reject: 1
-  #- filter: Bounds Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  where:
-  #  - variable:
-  #      name: MetaData/satelliteIdentifier
-  #    is_in: 3-5,421,440,821
-  #  test variables:
-  #  - name: MetaData/qualityFlags
-  #  minvalue: -0.1
-  #  maxvalue: 0.9
-  #  actions:
-  #  - name: set
-  #    flag: qfroCheckReject
-  #  - name: reject
-  
   #1. gpstop
   - filter: Domain Check
     filter variables:
@@ -97,14 +80,6 @@
       maxvalue: 55000.1
     action:
       name: reject
-  #2. Background check
-  #- filter: Background Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  threshold: 10
-  #  action:
-  #    name: reject
-  #  defer to post: true
   #3. RONBAM cut off check
   - filter: Background Check RONBAM
     filter variables:

--- a/observations/atmosphere/gnssro_paz.yaml.j2
+++ b/observations/atmosphere/gnssro_paz.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam
+    name: gnssrobndnbam_paz
     obsdatain:
       engine:
         type: H5File

--- a/observations/atmosphere/gnssro_paz.yaml.j2
+++ b/observations/atmosphere/gnssro_paz.yaml.j2
@@ -43,15 +43,6 @@
       initial value: false 
       force reinitialization: true
   
-  # Diagnostic flag for qfro
-  - filter: Create Diagnostic Flags
-    filter variables:
-    - name: bendingAngle
-    flags:
-    - name: qfroCheckReject
-      initial value: false
-      force reinitialization: true
-  
   # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
   - filter: Bounds Check
     filter variables:

--- a/observations/atmosphere/gnssro_piq.yaml.j2
+++ b/observations/atmosphere/gnssro_piq.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam
+    name: gnssrobndnbam_piq
     obsdatain:
       engine:
         type: H5File

--- a/observations/atmosphere/gnssro_piq.yaml.j2
+++ b/observations/atmosphere/gnssro_piq.yaml.j2
@@ -1,0 +1,130 @@
+-
+
+  # Observation Space (I/O)
+  # -----------------------
+  obs space:
+    name: gnssrobndnbam
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdatain_path}}/{{atmosphere_obsdatain_prefix}}{{observation_from_jcb}}{{atmosphere_obsdatain_suffix}}" 
+      obsgrouping:
+        group variables: [ 'sequenceNumber' ]
+        sort variable: 'impactHeightRO'
+        sort order: 'ascending'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"        
+    simulated variables: [bendingAngle]
+
+  # Observation Operator
+  # --------------------
+  obs operator:
+    name: GnssroBndNBAM
+    obs options:
+      use_compress: 1
+      sr_steps: 2
+      vertlayer: full
+      super_ref_qc: NBAM
+      output_diags: true
+
+  # Observation Filters (QC)
+  # ------------------------
+  obs filters:
+  # Apply gross check using pccf
+  # Step 0-A: Create Diagnostic Flags 
+  # Diagnostic flag for pccf
+  - filter: Create Diagnostic Flags
+    filter variables:  
+    - name: bendingAngle 
+    flags:
+    - name: pccfCheckReject
+      initial value: false 
+      force reinitialization: true
+  
+  # Diagnostic flag for qfro
+  - filter: Create Diagnostic Flags
+    filter variables:
+    - name: bendingAngle
+    flags:
+    - name: qfroCheckReject
+      initial value: false
+      force reinitialization: true
+  
+  # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
+  - filter: Bounds Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/satelliteIdentifier
+      is_in: 265-269,750-755,44,786,820,825
+    test variables:
+    - name: MetaData/pccf
+    minvalue: 0.1
+    maxvalue: 100.1
+    actions:
+    - name: set
+      flag: pccfCheckReject
+    - name: reject
+  
+  # Step 0-B: qfro Check - good: 0, reject: 1
+  #- filter: Bounds Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  where:
+  #  - variable:
+  #      name: MetaData/satelliteIdentifier
+  #    is_in: 3-5,421,440,821
+  #  test variables:
+  #  - name: MetaData/qualityFlags
+  #  minvalue: -0.1
+  #  maxvalue: 0.9
+  #  actions:
+  #  - name: set
+  #    flag: qfroCheckReject
+  #  - name: reject
+  
+  #1. commgpstop
+  - filter: Bounds Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/satelliteIdentifier
+      is_in: 265,266,267,268,269
+    test variables:
+    - name: MetaData/impactHeightRO
+    maxvalue: 45000.1
+    action:
+      name: reject
+  #2. Background check
+  #- filter: Background Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  threshold: 10
+  #  action:
+  #    name: reject
+  #  defer to post: true
+  #3. RONBAM cut off check
+  - filter: Background Check RONBAM
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: reject
+    defer to post: true
+  #4. assign obs error 
+  - filter: ROobserror
+    filter variables:
+    - name: bendingAngle
+    errmodel: NBAM
+    defer to post: true
+  #5. Obs error inflate
+  - filter: Perform Action
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: RONBAMErrInflate
+    defer to post: true
+  # --------------------------------

--- a/observations/atmosphere/gnssro_piq.yaml.j2
+++ b/observations/atmosphere/gnssro_piq.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam_piq
+    name: gnssrobndnbam
     obsdatain:
       engine:
         type: H5File
@@ -69,23 +69,6 @@
       flag: pccfCheckReject
     - name: reject
   
-  # Step 0-B: qfro Check - good: 0, reject: 1
-  #- filter: Bounds Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  where:
-  #  - variable:
-  #      name: MetaData/satelliteIdentifier
-  #    is_in: 3-5,421,440,821
-  #  test variables:
-  #  - name: MetaData/qualityFlags
-  #  minvalue: -0.1
-  #  maxvalue: 0.9
-  #  actions:
-  #  - name: set
-  #    flag: qfroCheckReject
-  #  - name: reject
-  
   #1. commgpstop
   - filter: Bounds Check
     filter variables:
@@ -99,14 +82,6 @@
     maxvalue: 45000.1
     action:
       name: reject
-  #2. Background check
-  #- filter: Background Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  threshold: 10
-  #  action:
-  #    name: reject
-  #  defer to post: true
   #3. RONBAM cut off check
   - filter: Background Check RONBAM
     filter variables:

--- a/observations/atmosphere/gnssro_piq.yaml.j2
+++ b/observations/atmosphere/gnssro_piq.yaml.j2
@@ -43,15 +43,6 @@
       initial value: false 
       force reinitialization: true
   
-  # Diagnostic flag for qfro
-  - filter: Create Diagnostic Flags
-    filter variables:
-    - name: bendingAngle
-    flags:
-    - name: qfroCheckReject
-      initial value: false
-      force reinitialization: true
-  
   # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
   - filter: Bounds Check
     filter variables:

--- a/observations/atmosphere/gnssro_s6.yaml.j2
+++ b/observations/atmosphere/gnssro_s6.yaml.j2
@@ -1,0 +1,128 @@
+-
+
+  # Observation Space (I/O)
+  # -----------------------
+  obs space:
+    name: gnssrobndnbam
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdatain_path}}/{{atmosphere_obsdatain_prefix}}{{observation_from_jcb}}{{atmosphere_obsdatain_suffix}}" 
+      obsgrouping:
+        group variables: [ 'sequenceNumber' ]
+        sort variable: 'impactHeightRO'
+        sort order: 'ascending'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"        
+    simulated variables: [bendingAngle]
+
+  # Observation Operator
+  # --------------------
+  obs operator:
+    name: GnssroBndNBAM
+    obs options:
+      use_compress: 1
+      sr_steps: 2
+      vertlayer: full
+      super_ref_qc: NBAM
+      output_diags: true
+
+  # Observation Filters (QC)
+  # ------------------------
+  obs filters:
+  # Apply gross check using pccf
+  # Step 0-A: Create Diagnostic Flags 
+  # Diagnostic flag for pccf
+  - filter: Create Diagnostic Flags
+    filter variables:  
+    - name: bendingAngle 
+    flags:
+    - name: pccfCheckReject
+      initial value: false 
+      force reinitialization: true
+  
+  # Diagnostic flag for qfro
+  - filter: Create Diagnostic Flags
+    filter variables:
+    - name: bendingAngle
+    flags:
+    - name: qfroCheckReject
+      initial value: false
+      force reinitialization: true
+  
+  # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
+  - filter: Bounds Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/satelliteIdentifier
+      is_in: 265-269,750-755,44,786,820,825
+    test variables:
+    - name: MetaData/pccf
+    minvalue: 0.1
+    maxvalue: 100.1
+    actions:
+    - name: set
+      flag: pccfCheckReject
+    - name: reject
+  
+  # Step 0-B: qfro Check - good: 0, reject: 1
+  #- filter: Bounds Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  where:
+  #  - variable:
+  #      name: MetaData/satelliteIdentifier
+  #    is_in: 3-5,421,440,821
+  #  test variables:
+  #  - name: MetaData/qualityFlags
+  #  minvalue: -0.1
+  #  maxvalue: 0.9
+  #  actions:
+  #  - name: set
+  #    flag: qfroCheckReject
+  #  - name: reject
+  
+  #1. gpstop
+  - filter: Domain Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/impactHeightRO
+      minvalue: 0
+      maxvalue: 55000.1
+    action:
+      name: reject
+  #2. Background check
+  #- filter: Background Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  threshold: 10
+  #  action:
+  #    name: reject
+  #  defer to post: true
+  #3. RONBAM cut off check
+  - filter: Background Check RONBAM
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: reject
+    defer to post: true
+  #4. assign obs error 
+  - filter: ROobserror
+    filter variables:
+    - name: bendingAngle
+    errmodel: NBAM
+    defer to post: true
+  #5. Obs error inflate
+  - filter: Perform Action
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: RONBAMErrInflate
+    defer to post: true
+  # --------------------------------

--- a/observations/atmosphere/gnssro_s6.yaml.j2
+++ b/observations/atmosphere/gnssro_s6.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam_s6
+    name: gnssrobndnbam
     obsdatain:
       engine:
         type: H5File
@@ -69,23 +69,6 @@
       flag: pccfCheckReject
     - name: reject
   
-  # Step 0-B: qfro Check - good: 0, reject: 1
-  #- filter: Bounds Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  where:
-  #  - variable:
-  #      name: MetaData/satelliteIdentifier
-  #    is_in: 3-5,421,440,821
-  #  test variables:
-  #  - name: MetaData/qualityFlags
-  #  minvalue: -0.1
-  #  maxvalue: 0.9
-  #  actions:
-  #  - name: set
-  #    flag: qfroCheckReject
-  #  - name: reject
-  
   #1. gpstop
   - filter: Domain Check
     filter variables:
@@ -97,14 +80,6 @@
       maxvalue: 55000.1
     action:
       name: reject
-  #2. Background check
-  #- filter: Background Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  threshold: 10
-  #  action:
-  #    name: reject
-  #  defer to post: true
   #3. RONBAM cut off check
   - filter: Background Check RONBAM
     filter variables:

--- a/observations/atmosphere/gnssro_s6.yaml.j2
+++ b/observations/atmosphere/gnssro_s6.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam
+    name: gnssrobndnbam_s6
     obsdatain:
       engine:
         type: H5File

--- a/observations/atmosphere/gnssro_s6.yaml.j2
+++ b/observations/atmosphere/gnssro_s6.yaml.j2
@@ -43,15 +43,6 @@
       initial value: false 
       force reinitialization: true
   
-  # Diagnostic flag for qfro
-  - filter: Create Diagnostic Flags
-    filter variables:
-    - name: bendingAngle
-    flags:
-    - name: qfroCheckReject
-      initial value: false
-      force reinitialization: true
-  
   # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
   - filter: Bounds Check
     filter variables:

--- a/observations/atmosphere/gnssro_spire.yaml.j2
+++ b/observations/atmosphere/gnssro_spire.yaml.j2
@@ -1,0 +1,130 @@
+-
+
+  # Observation Space (I/O)
+  # -----------------------
+  obs space:
+    name: gnssrobndnbam
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdatain_path}}/{{atmosphere_obsdatain_prefix}}{{observation_from_jcb}}{{atmosphere_obsdatain_suffix}}" 
+      obsgrouping:
+        group variables: [ 'sequenceNumber' ]
+        sort variable: 'impactHeightRO'
+        sort order: 'ascending'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"        
+    simulated variables: [bendingAngle]
+
+  # Observation Operator
+  # --------------------
+  obs operator:
+    name: GnssroBndNBAM
+    obs options:
+      use_compress: 1
+      sr_steps: 2
+      vertlayer: full
+      super_ref_qc: NBAM
+      output_diags: true
+
+  # Observation Filters (QC)
+  # ------------------------
+  obs filters:
+  # Apply gross check using pccf
+  # Step 0-A: Create Diagnostic Flags 
+  # Diagnostic flag for pccf
+  - filter: Create Diagnostic Flags
+    filter variables:  
+    - name: bendingAngle 
+    flags:
+    - name: pccfCheckReject
+      initial value: false 
+      force reinitialization: true
+  
+  # Diagnostic flag for qfro
+  - filter: Create Diagnostic Flags
+    filter variables:
+    - name: bendingAngle
+    flags:
+    - name: qfroCheckReject
+      initial value: false
+      force reinitialization: true
+  
+  # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
+  - filter: Bounds Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/satelliteIdentifier
+      is_in: 265-269,750-755,44,786,820,825
+    test variables:
+    - name: MetaData/pccf
+    minvalue: 0.1
+    maxvalue: 100.1
+    actions:
+    - name: set
+      flag: pccfCheckReject
+    - name: reject
+  
+  # Step 0-B: qfro Check - good: 0, reject: 1
+  #- filter: Bounds Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  where:
+  #  - variable:
+  #      name: MetaData/satelliteIdentifier
+  #    is_in: 3-5,421,440,821
+  #  test variables:
+  #  - name: MetaData/qualityFlags
+  #  minvalue: -0.1
+  #  maxvalue: 0.9
+  #  actions:
+  #  - name: set
+  #    flag: qfroCheckReject
+  #  - name: reject
+  
+  #1. commgpstop
+  - filter: Bounds Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/satelliteIdentifier
+      is_in: 265,266,267,268,269
+    test variables:
+    - name: MetaData/impactHeightRO
+    maxvalue: 45000.1
+    action:
+      name: reject
+  #2. Background check
+  #- filter: Background Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  threshold: 10
+  #  action:
+  #    name: reject
+  #  defer to post: true
+  #3. RONBAM cut off check
+  - filter: Background Check RONBAM
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: reject
+    defer to post: true
+  #4. assign obs error 
+  - filter: ROobserror
+    filter variables:
+    - name: bendingAngle
+    errmodel: NBAM
+    defer to post: true
+  #5. Obs error inflate
+  - filter: Perform Action
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: RONBAMErrInflate
+    defer to post: true
+  # --------------------------------

--- a/observations/atmosphere/gnssro_spire.yaml.j2
+++ b/observations/atmosphere/gnssro_spire.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam_spire
+    name: gnssrobndnbam
     obsdatain:
       engine:
         type: H5File
@@ -69,23 +69,6 @@
       flag: pccfCheckReject
     - name: reject
   
-  # Step 0-B: qfro Check - good: 0, reject: 1
-  #- filter: Bounds Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  where:
-  #  - variable:
-  #      name: MetaData/satelliteIdentifier
-  #    is_in: 3-5,421,440,821
-  #  test variables:
-  #  - name: MetaData/qualityFlags
-  #  minvalue: -0.1
-  #  maxvalue: 0.9
-  #  actions:
-  #  - name: set
-  #    flag: qfroCheckReject
-  #  - name: reject
-  
   #1. commgpstop
   - filter: Bounds Check
     filter variables:
@@ -99,14 +82,6 @@
     maxvalue: 45000.1
     action:
       name: reject
-  #2. Background check
-  #- filter: Background Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  threshold: 10
-  #  action:
-  #    name: reject
-  #  defer to post: true
   #3. RONBAM cut off check
   - filter: Background Check RONBAM
     filter variables:

--- a/observations/atmosphere/gnssro_spire.yaml.j2
+++ b/observations/atmosphere/gnssro_spire.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam
+    name: gnssrobndnbam_spire
     obsdatain:
       engine:
         type: H5File

--- a/observations/atmosphere/gnssro_spire.yaml.j2
+++ b/observations/atmosphere/gnssro_spire.yaml.j2
@@ -43,15 +43,6 @@
       initial value: false 
       force reinitialization: true
   
-  # Diagnostic flag for qfro
-  - filter: Create Diagnostic Flags
-    filter variables:
-    - name: bendingAngle
-    flags:
-    - name: qfroCheckReject
-      initial value: false
-      force reinitialization: true
-  
   # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
   - filter: Bounds Check
     filter variables:

--- a/observations/atmosphere/gnssro_tdm.yaml.j2
+++ b/observations/atmosphere/gnssro_tdm.yaml.j2
@@ -1,0 +1,128 @@
+-
+
+  # Observation Space (I/O)
+  # -----------------------
+  obs space:
+    name: gnssrobndnbam
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdatain_path}}/{{atmosphere_obsdatain_prefix}}{{observation_from_jcb}}{{atmosphere_obsdatain_suffix}}" 
+      obsgrouping:
+        group variables: [ 'sequenceNumber' ]
+        sort variable: 'impactHeightRO'
+        sort order: 'ascending'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"        
+    simulated variables: [bendingAngle]
+
+  # Observation Operator
+  # --------------------
+  obs operator:
+    name: GnssroBndNBAM
+    obs options:
+      use_compress: 1
+      sr_steps: 2
+      vertlayer: full
+      super_ref_qc: NBAM
+      output_diags: true
+
+  # Observation Filters (QC)
+  # ------------------------
+  obs filters:
+  # Apply gross check using pccf
+  # Step 0-A: Create Diagnostic Flags 
+  # Diagnostic flag for pccf
+  - filter: Create Diagnostic Flags
+    filter variables:  
+    - name: bendingAngle 
+    flags:
+    - name: pccfCheckReject
+      initial value: false 
+      force reinitialization: true
+  
+  # Diagnostic flag for qfro
+  - filter: Create Diagnostic Flags
+    filter variables:
+    - name: bendingAngle
+    flags:
+    - name: qfroCheckReject
+      initial value: false
+      force reinitialization: true
+  
+  # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
+  - filter: Bounds Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/satelliteIdentifier
+      is_in: 265-269,750-755,44,786,820,825
+    test variables:
+    - name: MetaData/pccf
+    minvalue: 0.1
+    maxvalue: 100.1
+    actions:
+    - name: set
+      flag: pccfCheckReject
+    - name: reject
+  
+  # Step 0-B: qfro Check - good: 0, reject: 1
+  #- filter: Bounds Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  where:
+  #  - variable:
+  #      name: MetaData/satelliteIdentifier
+  #    is_in: 3-5,421,440,821
+  #  test variables:
+  #  - name: MetaData/qualityFlags
+  #  minvalue: -0.1
+  #  maxvalue: 0.9
+  #  actions:
+  #  - name: set
+  #    flag: qfroCheckReject
+  #  - name: reject
+  
+  #1. gpstop
+  - filter: Domain Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/impactHeightRO
+      minvalue: 0
+      maxvalue: 55000.1
+    action:
+      name: reject
+  #2. Background check
+  #- filter: Background Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  threshold: 10
+  #  action:
+  #    name: reject
+  #  defer to post: true
+  #3. RONBAM cut off check
+  - filter: Background Check RONBAM
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: reject
+    defer to post: true
+  #4. assign obs error 
+  - filter: ROobserror
+    filter variables:
+    - name: bendingAngle
+    errmodel: NBAM
+    defer to post: true
+  #5. Obs error inflate
+  - filter: Perform Action
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: RONBAMErrInflate
+    defer to post: true
+  # --------------------------------

--- a/observations/atmosphere/gnssro_tdm.yaml.j2
+++ b/observations/atmosphere/gnssro_tdm.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam
+    name: gnssrobndnbam_tdm
     obsdatain:
       engine:
         type: H5File

--- a/observations/atmosphere/gnssro_tdm.yaml.j2
+++ b/observations/atmosphere/gnssro_tdm.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam_tdm
+    name: gnssrobndnbam
     obsdatain:
       engine:
         type: H5File
@@ -69,23 +69,6 @@
       flag: pccfCheckReject
     - name: reject
   
-  # Step 0-B: qfro Check - good: 0, reject: 1
-  #- filter: Bounds Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  where:
-  #  - variable:
-  #      name: MetaData/satelliteIdentifier
-  #    is_in: 3-5,421,440,821
-  #  test variables:
-  #  - name: MetaData/qualityFlags
-  #  minvalue: -0.1
-  #  maxvalue: 0.9
-  #  actions:
-  #  - name: set
-  #    flag: qfroCheckReject
-  #  - name: reject
-  
   #1. gpstop
   - filter: Domain Check
     filter variables:
@@ -97,14 +80,6 @@
       maxvalue: 55000.1
     action:
       name: reject
-  #2. Background check
-  #- filter: Background Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  threshold: 10
-  #  action:
-  #    name: reject
-  #  defer to post: true
   #3. RONBAM cut off check
   - filter: Background Check RONBAM
     filter variables:

--- a/observations/atmosphere/gnssro_tdm.yaml.j2
+++ b/observations/atmosphere/gnssro_tdm.yaml.j2
@@ -43,15 +43,6 @@
       initial value: false 
       force reinitialization: true
   
-  # Diagnostic flag for qfro
-  - filter: Create Diagnostic Flags
-    filter variables:
-    - name: bendingAngle
-    flags:
-    - name: qfroCheckReject
-      initial value: false
-      force reinitialization: true
-  
   # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
   - filter: Bounds Check
     filter variables:

--- a/observations/atmosphere/gnssro_tsx.yaml.j2
+++ b/observations/atmosphere/gnssro_tsx.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam_tsx
+    name: gnssrobndnbam
     obsdatain:
       engine:
         type: H5File
@@ -69,23 +69,6 @@
       flag: pccfCheckReject
     - name: reject
   
-  # Step 0-B: qfro Check - good: 0, reject: 1
-  #- filter: Bounds Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  where:
-  #  - variable:
-  #      name: MetaData/satelliteIdentifier
-  #    is_in: 3-5,421,440,821
-  #  test variables:
-  #  - name: MetaData/qualityFlags
-  #  minvalue: -0.1
-  #  maxvalue: 0.9
-  #  actions:
-  #  - name: set
-  #    flag: qfroCheckReject
-  #  - name: reject
-  
   #1. gpstop
   - filter: Domain Check
     filter variables:
@@ -97,14 +80,6 @@
       maxvalue: 55000.1
     action:
       name: reject
-  #2. Background check
-  #- filter: Background Check
-  #  filter variables:
-  #  - name: bendingAngle
-  #  threshold: 10
-  #  action:
-  #    name: reject
-  #  defer to post: true
   #3. RONBAM cut off check
   - filter: Background Check RONBAM
     filter variables:

--- a/observations/atmosphere/gnssro_tsx.yaml.j2
+++ b/observations/atmosphere/gnssro_tsx.yaml.j2
@@ -1,0 +1,128 @@
+-
+
+  # Observation Space (I/O)
+  # -----------------------
+  obs space:
+    name: gnssrobndnbam
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdatain_path}}/{{atmosphere_obsdatain_prefix}}{{observation_from_jcb}}{{atmosphere_obsdatain_suffix}}" 
+      obsgrouping:
+        group variables: [ 'sequenceNumber' ]
+        sort variable: 'impactHeightRO'
+        sort order: 'ascending'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"        
+    simulated variables: [bendingAngle]
+
+  # Observation Operator
+  # --------------------
+  obs operator:
+    name: GnssroBndNBAM
+    obs options:
+      use_compress: 1
+      sr_steps: 2
+      vertlayer: full
+      super_ref_qc: NBAM
+      output_diags: true
+
+  # Observation Filters (QC)
+  # ------------------------
+  obs filters:
+  # Apply gross check using pccf
+  # Step 0-A: Create Diagnostic Flags 
+  # Diagnostic flag for pccf
+  - filter: Create Diagnostic Flags
+    filter variables:  
+    - name: bendingAngle 
+    flags:
+    - name: pccfCheckReject
+      initial value: false 
+      force reinitialization: true
+  
+  # Diagnostic flag for qfro
+  - filter: Create Diagnostic Flags
+    filter variables:
+    - name: bendingAngle
+    flags:
+    - name: qfroCheckReject
+      initial value: false
+      force reinitialization: true
+  
+  # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
+  - filter: Bounds Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/satelliteIdentifier
+      is_in: 265-269,750-755,44,786,820,825
+    test variables:
+    - name: MetaData/pccf
+    minvalue: 0.1
+    maxvalue: 100.1
+    actions:
+    - name: set
+      flag: pccfCheckReject
+    - name: reject
+  
+  # Step 0-B: qfro Check - good: 0, reject: 1
+  #- filter: Bounds Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  where:
+  #  - variable:
+  #      name: MetaData/satelliteIdentifier
+  #    is_in: 3-5,421,440,821
+  #  test variables:
+  #  - name: MetaData/qualityFlags
+  #  minvalue: -0.1
+  #  maxvalue: 0.9
+  #  actions:
+  #  - name: set
+  #    flag: qfroCheckReject
+  #  - name: reject
+  
+  #1. gpstop
+  - filter: Domain Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/impactHeightRO
+      minvalue: 0
+      maxvalue: 55000.1
+    action:
+      name: reject
+  #2. Background check
+  #- filter: Background Check
+  #  filter variables:
+  #  - name: bendingAngle
+  #  threshold: 10
+  #  action:
+  #    name: reject
+  #  defer to post: true
+  #3. RONBAM cut off check
+  - filter: Background Check RONBAM
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: reject
+    defer to post: true
+  #4. assign obs error 
+  - filter: ROobserror
+    filter variables:
+    - name: bendingAngle
+    errmodel: NBAM
+    defer to post: true
+  #5. Obs error inflate
+  - filter: Perform Action
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: RONBAMErrInflate
+    defer to post: true
+  # --------------------------------

--- a/observations/atmosphere/gnssro_tsx.yaml.j2
+++ b/observations/atmosphere/gnssro_tsx.yaml.j2
@@ -3,7 +3,7 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: gnssrobndnbam
+    name: gnssrobndnbam_tsx
     obsdatain:
       engine:
         type: H5File

--- a/observations/atmosphere/gnssro_tsx.yaml.j2
+++ b/observations/atmosphere/gnssro_tsx.yaml.j2
@@ -43,15 +43,6 @@
       initial value: false 
       force reinitialization: true
   
-  # Diagnostic flag for qfro
-  - filter: Create Diagnostic Flags
-    filter variables:
-    - name: bendingAngle
-    flags:
-    - name: qfroCheckReject
-      initial value: false
-      force reinitialization: true
-  
   # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
   - filter: Bounds Check
     filter variables:


### PR DESCRIPTION
Adding gnssro_**mission**.yaml.j2 data. The GNSS RO data is reorganized so each satellite mission has its own yaml file.