### PR TITLE
change aerosol gaussian increment from ges res to anl res

### DIFF
--- a/model/aero/aero_final_increment_gaussian.yaml.j2
+++ b/model/aero/aero_final_increment_gaussian.yaml.j2
@@ -2,7 +2,7 @@ grid type: regular gaussian
 local interpolator type: atlas interpolator
 interpolation method:
   type: finite-element
-number of latitude gridpoints: {{ aero_npy_ges - 1 }}
+number of latitude gridpoints: {{ aero_npy_anl - 1 }}
 variables to output: [mass_fraction_of_sulfate_in_air,
                        mass_fraction_of_hydrophobic_black_carbon_in_air,
                        mass_fraction_of_hydrophilic_black_carbon_in_air,


### PR DESCRIPTION
OOPS chokes trying to interpolate and write a C1152 equivalent Gaussian increment, and we don't need that anyways for now, so instead write out an increment at the analysis resolution (C384)