### PR TITLE
Add aerosol bias correction to yaml templates

### DIFF
--- a/model/aero/aero_background.yaml.j2
+++ b/model/aero/aero_background.yaml.j2
@@ -4,7 +4,8 @@ datetime: '{{ aero_background_time_iso }}'
 filename is datetime templated: true
 filename_core: '%yyyy%mm%dd.%hh%MM%ss.fv_core.res.nc'
 filename_trcr: '%yyyy%mm%dd.%hh%MM%ss.fv_tracer.res.nc'
+filename_sfcd: '%yyyy%mm%dd.%hh%MM%ss.sfc_data.nc'
 filename_cplr: '%yyyy%mm%dd.%hh%MM%ss.coupler.res'
 state variables: [t,delp,sphum,so4,bc1,bc2,oc1,oc2,
                     dust1,dust2,dust3,dust4,dust5,
-                    seas1,seas2,seas3,seas4]
+                    seas1,seas2,seas3,seas4,slmsk,sheleg]

--- a/observations/aero/viirs_n20_aod.yaml.j2
+++ b/observations/aero/viirs_n20_aod.yaml.j2
@@ -41,7 +41,7 @@
     variational bc:
       predictors:
       - name: constant
-        surface: slmask
+        surface: land sea mask
     covariance:
       minimal required obs number: 20
       variance range: [1.0e-6, 10.0]

--- a/observations/aero/viirs_n20_aod.yaml.j2
+++ b/observations/aero/viirs_n20_aod.yaml.j2
@@ -35,6 +35,24 @@
 
   # Observation Bias Correction (VarBC)
   # -----------------------------------
+  obs bias:
+    input file: "{{aero_obsbiasin_path}}/{{aero_obsbiasin_prefix}}{{observation_from_jcb}}{{aero_obsbiasin_suffix}}"
+    output file: "{{aero_obsbiasout_path}}/{{aero_obsbiasout_prefix}}{{observation_from_jcb}}{{aero_obsbiasout_suffix}}"
+    variational bc:
+      predictors:
+      - name: constant
+        surface: slmask
+    covariance:
+      minimal required obs number: 20
+      variance range: [1.0e-6, 10.0]
+      step size: 1.0e-4
+      largest analysis variance: 10000.0
+      prior:
+        input file: "{{aero_obsbiasin_path}}/{{aero_obsbiascovin_prefix}}{{observation_from_jcb}}{{aero_obsbiascovin_suffix}}"
+        inflation:
+          ratio: 1.1
+          ratio for small dataset: 2.0
+      output file: "{{aero_obsbiasout_path}}/{{aero_obsbiascovout_prefix}}{{observation_from_jcb}}{{aero_obsbiascovout_suffix}}"
 
   # Observation Filters (QC)
   # ------------------------  


### PR DESCRIPTION
The current aerosol DA templates does not have bias correction.
In this PR, aerosol bias correction section is added to the viirs n20 observation templates. 
To use the Constant predictor with land-sea mask feature, sfc_data and slmsk variable will be added to the aerosol background template.
