### PR TITLE
Add template yaml files for snow LETKF

### DIFF
--- a/model/snow/snow_background_ensemble_letkf.yaml.j2
+++ b/model/snow/snow_background_ensemble_letkf.yaml.j2
@@ -1,0 +1,13 @@
+members:
+  - datetime: '{{ snow_background_time_iso }}'
+    filetype: fms restart
+    state variables: [{{ snowdepth_vn }},vtype,slmsk]
+    datapath: mem1
+    filename_sfcd: '{{ snow_background_time_fv3 }}.sfc_data.nc'
+    filename_cplr: '{{ snow_background_time_fv3 }}.coupler.res'
+  - datetime: '{{ snow_background_time_iso }}'
+    filetype: fms restart
+    state variables: [{{ snowdepth_vn }},vtype,slmsk]
+    datapath: mem2
+    filename_sfcd: '{{ snow_background_time_fv3 }}.sfc_data.nc'
+    filename_cplr: '{{ snow_background_time_fv3 }}.coupler.res'

--- a/model/snow/snow_geometry_background_letkf.yaml.j2
+++ b/model/snow/snow_geometry_background_letkf.yaml.j2
@@ -1,0 +1,17 @@
+fms initialization:
+  namelist filename: "{{ snow_fv3jedi_files_path }}/fmsmpp.nml"
+  field table filename: "{{ snow_fv3jedi_files_path }}/field_table"
+akbk: {{ snow_fv3jedi_files_path }}/akbk.nc4
+npx: {{ snow_npx_anl }}
+npy: {{ snow_npy_anl }}
+npz: {{ snow_npz_anl }}
+field metadata override: "{{ snow_fv3jedi_files_path }}/fv3jedi_fieldmetadata_restart.yaml"
+time invariant fields:
+  state fields:
+    datetime: '{{ snow_background_time_iso }}'
+    filetype: fms restart
+    skip coupler file: true
+    state variables: [orog_filt]
+    datapath: {{ snow_orog_files_path }}
+    filename_orog: {{ snow_orog_prefix }}_oro_data.nc
+  derived fields: [nominal_surface_pressure]

--- a/model/snow/snow_output_increment_letkf.yaml.j2
+++ b/model/snow/snow_output_increment_letkf.yaml.j2
@@ -1,0 +1,2 @@
+filetype: fms restart
+filename_sfcd: snowinc.sfc_data.nc

--- a/observations/snow/ghcn_snow.yaml.j2
+++ b/observations/snow/ghcn_snow.yaml.j2
@@ -4,6 +4,8 @@
   # -----------------------
   obs space:
     name: ghcn_snow
+    distribution:
+      name: InefficientDistribution
     obsdatain:
       engine:
         type: H5File
@@ -20,6 +22,15 @@
   # --------------------
   obs operator:
     name: Identity
+  obs error:
+    covariance model: diagonal
+  obs localizations:
+  - localization method: Horizontal SOAR
+    lengthscale: 250e3
+    soar horizontal decay: 0.000021
+    max nobs: 50
+  - localization method: Vertical Brasnett
+    vertical lengthscale: 700
   #
 
   # Observation Filters (QC)
@@ -29,11 +40,13 @@
       filter variables:
       - name: totalSnowDepth
       minvalue: 0.0
+      maxvalue: 10000.0
     - filter: Domain Check
       where:
       - variable:
           name: MetaData/stationElevation
-        value: is_valid
+        minvalue: -999.0
+        maxvalue: 10000.0
     - filter: Domain Check # land only
       where:
       - variable:
@@ -46,10 +59,6 @@
           name: GeoVaLs/vtype
         minvalue: 14.5
         maxvalue: 15.5
-    - filter: Difference Check # elevation check
-      reference: MetaData/stationElevation
-      value: GeoVaLs/filtered_orography
-      threshold: 200.
     - filter: Background Check
       filter variables:
       - name: totalSnowDepth


### PR DESCRIPTION
- Add the template yaml files for snow LETKF.
- JEDI algorithms: `local_ensemble_da`
- Update the `ghcn_snow` yaml file based on the sample file of `fv3-jedi` ([letkf_snow.yaml](https://github.com/JCSDA/fv3-jedi/blob/develop/test/testinput/letkf_snow.yaml))
- Dependent PR in `NOAA-EMC/jcb-algorithms`: [PR#13](https://github.com/NOAA-EMC/jcb-algorithms/pull/13)
- This was tested in the UFS land-DA workflow ([PR#205](https://github.com/ufs-community/land-DA_workflow/pull/205)).
- The above `ghcn_snow` yaml file was tested with two JEDI algorithms; `3d-var` and `letkf`.