### PR TITLE
group snow obs by stationID

### DIFF
--- a/observations/snow/adpsfc_snow.yaml.j2
+++ b/observations/snow/adpsfc_snow.yaml.j2
@@ -9,6 +9,8 @@
         type: H5File
         obsfile: "{{snow_obsdatain_path}}/{{snow_obsdatain_prefix}}{{observation_from_jcb}}{{snow_obsdatain_suffix}}"
         missing file action: warn
+      obsgrouping:
+        group variables: [stationIdentification]
     obsdataout:
       engine:
         type: H5File

--- a/observations/snow/sfcsno.yaml.j2
+++ b/observations/snow/sfcsno.yaml.j2
@@ -10,6 +10,8 @@
         obsfile: "{{snow_obsdatain_path}}/{{snow_obsdatain_prefix}}sfcsno.tm00.bufr_d"
         mapping file: "{{snow_obsdatain_path}}/bufr_sfcsno_mapping.yaml"
         missing file action: warn
+      obsgrouping:
+          group variables: [stationIdentification]
     obsdataout:
       engine:
         type: H5File

--- a/observations/snow/snocvr_snow.yaml.j2
+++ b/observations/snow/snocvr_snow.yaml.j2
@@ -9,6 +9,8 @@
         type: H5File
         obsfile: "{{snow_obsdatain_path}}/{{snow_obsdatain_prefix}}{{observation_from_jcb}}.nc4"
         missing file action: warn
+      obsgrouping:
+        group variables: [stationIdentification]
     obsdataout:
       engine:
         type: H5File


### PR DESCRIPTION
https://github.com/NOAA-EMC/GDASApp/issues/1576 discussion found reproducibility issues between PE counts for snow 2DVar. I tracked it down to the temporal thinning filter. When not explicitly grouping by stationID at IODA, reproducibility issues can occur. Thus, we should group by stationID when the obs space is created.