### PR TITLE
add state variables to inverse block to gsibec templates

### DIFF
--- a/model/atmosphere/atmosphere_background_error_hybrid_gsibec_bump.yaml.j2
+++ b/model/atmosphere/atmosphere_background_error_hybrid_gsibec_bump.yaml.j2
@@ -19,6 +19,9 @@ components:
       processor layout x direction: {{atmosphere_layout_gsib_x}}
       processor layout y direction: {{atmosphere_layout_gsib_y}}
       debugging mode: false
+      state variables to inverse: [eastward_wind,northward_wind,air_temperature,air_pressure_at_surface,
+                                   water_vapor_mixing_ratio_wrt_moist_air,cloud_liquid_ice,cloud_liquid_water,
+                                   ozone_mass_mixing_ratio]
     linear variable change:
       linear variable change name: Control2Analysis
       input variables: [eastward_wind,northward_wind,air_temperature,air_pressure_at_surface,

--- a/model/atmosphere/atmosphere_background_error_static_gsibec.yaml.j2
+++ b/model/atmosphere/atmosphere_background_error_static_gsibec.yaml.j2
@@ -17,6 +17,9 @@ saber outer blocks:
   processor layout x direction: {{atmosphere_layout_gsib_x}}
   processor layout y direction: {{atmosphere_layout_gsib_y}}
   debugging mode: false
+  state variables to inverse: [eastward_wind,northward_wind,air_temperature,air_pressure_at_surface,
+                               water_vapor_mixing_ratio_wrt_moist_air,cloud_liquid_ice,cloud_liquid_water,
+                               ozone_mass_mixing_ratio]
 linear variable change:
   linear variable change name: Control2Analysis
   input variables: [eastward_wind,northward_wind,air_temperature,air_pressure_at_surface,


### PR DESCRIPTION
This PR adds the `state variables to inverse` block to
- `model/atmosphere/atmosphere_background_error_hybrid_gsibec_bump.yaml.j2`
- `model/atmosphere/atmosphere_background_error_static_gsibec.yaml.j2`

Updates to saber at [dce89ba](https://github.com/JCSDA/saber/commit/dce89bab2223ffd00f98e25c28a5ee11bd67c542) and fv3-jedi at [7e8337d](https://github.com/JCSDA/fv3-jedi/commit/7e8337ddb7ebcbfcce3a62d5fb282ca092586e7d) require addition of a state variables to inverse block in GSIBEC yamls.

See saber PR [#1022](https://github.com/JCSDA-internal/saber/pull/1022) and fv3-jedi PR [#1350](https://github.com/JCSDA-internal/fv3-jedi/pull/1350) for details.

Resolves #92

The changes in this PR have been tested in GDASApp `feature/stable-nightly` and found to work.