### PR TITLE
Temporarily reverted cloud_fraction=1.0.

### DIFF
--- a/observations/atmosphere/amsua_n19.yaml.j2
+++ b/observations/atmosphere/amsua_n19.yaml.j2
@@ -23,10 +23,10 @@
     name: CRTM
     Absorbers: [H2O, O3, CO2]
     Clouds: &{{observation_from_jcb}}_clouds [Water, Ice, Rain, Snow, Graupel]
-#   Cloud_Fraction: 1.0
+    Cloud_Fraction: 1.0
 #   ---methods for cloud fraction and radii in fov: thompson, or none
-    method for cloud fraction within fov: thompson
-    method for hydrometeor effective radii within fov: thompson
+    method for cloud fraction within fov: none
+    method for hydrometeor effective radii within fov: none
     Cloud_Seeding: true
     obs options:
       Sensor_ID: &{{observation_from_jcb}}_sensor_id amsua_n19

--- a/observations/atmosphere/atms_n20.yaml.j2
+++ b/observations/atmosphere/atms_n20.yaml.j2
@@ -23,10 +23,10 @@
     name: CRTM
     Absorbers: [H2O, O3, CO2]
     Clouds: &{{observation_from_jcb}}_clouds [Water, Ice, Rain, Snow, Graupel]
-#   Cloud_Fraction: 1.0
+    Cloud_Fraction: 1.0
 #   ---methods for cloud fraction and radii in fov: thompson, or none
-    method for cloud fraction within fov: thompson
-    method for hydrometeor effective radii within fov: thompson
+    method for cloud fraction within fov: none
+    method for hydrometeor effective radii within fov: none
     Cloud_Seeding: true
     obs options:
       Sensor_ID: &{{observation_from_jcb}}_sensor_id atms_n20

--- a/observations/atmosphere/atms_n21.yaml.j2
+++ b/observations/atmosphere/atms_n21.yaml.j2
@@ -23,10 +23,10 @@
     name: CRTM
     Absorbers: [H2O, O3, CO2]
     Clouds: &{{observation_from_jcb}}_clouds [Water, Ice, Rain, Snow, Graupel]
-#   Cloud_Fraction: 1.0
+    Cloud_Fraction: 1.0
 #   ---methods for cloud fraction and radii in fov: thompson, or none
-    method for cloud fraction within fov: thompson
-    method for hydrometeor effective radii within fov: thompson
+    method for cloud fraction within fov: none
+    method for hydrometeor effective radii within fov: none
     Cloud_Seeding: true
     obs options:
       Sensor_ID: &{{observation_from_jcb}}_sensor_id atms_n21

--- a/observations/atmosphere/atms_npp.yaml.j2
+++ b/observations/atmosphere/atms_npp.yaml.j2
@@ -23,10 +23,10 @@
     name: CRTM
     Absorbers: [H2O, O3, CO2]
     Clouds: &{{observation_from_jcb}}_clouds [Water, Ice, Rain, Snow, Graupel]
-#   Cloud_Fraction: 1.0
+    Cloud_Fraction: 1.0
 #   ---methods for cloud fraction and radii in fov: thompson, or none
-    method for cloud fraction within fov: thompson
-    method for hydrometeor effective radii within fov: thompson
+    method for cloud fraction within fov: none
+    method for hydrometeor effective radii within fov: none
     Cloud_Seeding: true
     obs options:
       Sensor_ID: &{{observation_from_jcb}}_sensor_id atms_npp


### PR DESCRIPTION
Temporarily turned off the calculations of cloud fraction and particle radii by the Thompson method because of missing geoval "moist_air_density".  See the note of it https://github.com/NOAA-EMC/GDASApp/issues/1573#issuecomment-2791277591 .  Working on adding the variable in FV-3JEDI.  