### PR TITLE
Bugfix for marine qc filters

### DIFF
--- a/observations/marine/insitu_profile_bathy.yaml.j2
+++ b/observations/marine/insitu_profile_bathy.yaml.j2
@@ -9,6 +9,7 @@
         type: H5File
         obsfile: "{{marine_obsdataout_path}}/{{marine_obsdataout_prefix}}{{observation_from_jcb}}{{marine_obsdataout_suffix}}"
     simulated variables: [waterTemperature]
+    observed variable: [waterTemperature]
     io pool:
       max pool size: 1
   obs operator:

--- a/observations/marine/insitu_surface_altkob.yaml.j2
+++ b/observations/marine/insitu_surface_altkob.yaml.j2
@@ -9,6 +9,7 @@
         type: H5File
         obsfile: "{{marine_obsdataout_path}}/{{marine_obsdataout_prefix}}{{observation_from_jcb}}{{marine_obsdataout_suffix}}"
     simulated variables: [seaSurfaceTemperature]
+    observed variables: [seaSurfaceTemperature]
     io pool:
       max pool size: 1
   obs operator:

--- a/observations/marine/insitu_surface_trkob.yaml.j2
+++ b/observations/marine/insitu_surface_trkob.yaml.j2
@@ -9,6 +9,7 @@
         type: H5File
         obsfile: "{{marine_obsdataout_path}}/{{marine_obsdataout_prefix}}{{observation_from_jcb}}{{marine_obsdataout_suffix}}"
     simulated variables: [seaSurfaceTemperature]
+    observed variables: [seaSurfaceTemperature]
     io pool:
       max pool size: 1
   obs operator:

--- a/observations/marine/insitu_surface_trkob_salinity.yaml.j2
+++ b/observations/marine/insitu_surface_trkob_salinity.yaml.j2
@@ -9,6 +9,7 @@
         type: H5File
         obsfile: "{{marine_obsdataout_path}}/{{marine_obsdataout_prefix}}{{observation_from_jcb}}{{marine_obsdataout_suffix}}"
     simulated variables: [seaSurfaceSalinity]
+    observed variables: [seaSurfaceSalinity]
   get values:
     time interpolation: linear
   obs operator:

--- a/observations/marine/sst_generic.yaml.j2
+++ b/observations/marine/sst_generic.yaml.j2
@@ -56,6 +56,8 @@
 {% endif %}
 
   obs post filters:
+  - filter: Background Check
+    absolute threshold: 5.0
   - filter: Perform Action  # Pamlico Sound & Chesapeake Bay
     action:
       name: accept
@@ -68,5 +70,6 @@
         name: MetaData/longitude
       minvalue: -76.88
       maxvalue: -74.5
-  - filter: Background Check
-    absolute threshold: 5.0
+# TODO: var fails when bkg chk filter is last
+#  - filter: Background Check
+#    absolute threshold: 5.0


### PR DESCRIPTION
This bugfix PR addresses an ordering issue in the post filters of sst_generic.yaml.j2 and adds "observed variables" that are missing in several of the in situ observation yamls. 

The missing "observed variables" in bathy, altkob, trkob and trkob_salinity causes the gdas_prepoceanobs task to fail. Using the background check at the end of the post filters in sst_generic.yaml.j2 cause the gdas_marineanlvar task to fail.
 
These bugfix changes were successfully tested on Hera.