### PR TITLE
updates to allow atmospheric DA with all-sky microwave assimilation

### DIFF
--- a/model/atmosphere/atmosphere_background.yaml.j2
+++ b/model/atmosphere/atmosphere_background.yaml.j2
@@ -3,6 +3,6 @@ filetype: cube sphere history
 provider: ufs
 datetime: "{{ atmosphere_background_time_iso }}"
 filenames: [ {{ atmosphere_variational_history_prefix }}cubed_sphere_grid_atmf006.nc, {{ atmosphere_variational_history_prefix }}cubed_sphere_grid_sfcf006.nc ]
-state variables: [ua,va,t,delp,ps,sphum,ice_wat,liq_wat,o3mr,hgtsfc,
+state variables: [ua,va,t,delp,ps,sphum,ice_wat,liq_wat,snmr,rwmr,grle,nccice,nconrd,o3mr,hgtsfc,
                   slmsk,sheleg,tmpsfc,vtype,stype,vfrac,soilt1,soilw1,snwdphMeters,
                   u_srf,v_srf,f10m]

--- a/model/atmosphere/atmosphere_background_ensemble.yaml.j2
+++ b/model/atmosphere/atmosphere_background_ensemble.yaml.j2
@@ -4,7 +4,7 @@ members from template:
     datetime: '{{ atmosphere_background_time_iso }}'
     filetype: cube sphere history
     provider: ufs
-    state variables: [ua,va,t,delz,delp,ps,sphum,ice_wat,liq_wat,o3mr,hgtsfc,
+    state variables: [ua,va,t,delz,delp,ps,sphum,ice_wat,liq_wat,snmr,rwmr,grle,nccice,nconrd,o3mr,hgtsfc,
                      slmsk,sheleg,tmpsfc,vtype,stype,vfrac,soilt1,soilw1,snwdphMeters,
                      u_srf,v_srf,f10m]
     datapath: {{ atmosphere_background_ensemble_path }}

--- a/observations/atmosphere/amsua_n19.yaml.j2
+++ b/observations/atmosphere/amsua_n19.yaml.j2
@@ -34,6 +34,7 @@
       CoefficientPath: "{{crtm_coefficient_path}}"
     linear obs operator:
       Absorbers: [H2O, O3]
+      Clouds: &{{observation_from_jcb}}_clouds
 
   # Observation Bias Correction (VarBC)
   # -----------------------------------

--- a/observations/atmosphere/amsua_n19.yaml.j2
+++ b/observations/atmosphere/amsua_n19.yaml.j2
@@ -34,7 +34,6 @@
       CoefficientPath: "{{crtm_coefficient_path}}"
     linear obs operator:
       Absorbers: [H2O, O3]
-      Clouds: &{{observation_from_jcb}}_clouds
 
   # Observation Bias Correction (VarBC)
   # -----------------------------------

--- a/observations/atmosphere/amsua_n19.yaml.j2
+++ b/observations/atmosphere/amsua_n19.yaml.j2
@@ -34,7 +34,7 @@
       CoefficientPath: "{{crtm_coefficient_path}}"
     linear obs operator:
       Absorbers: [H2O, O3]
-      Clouds: *{{observation_from_jcb}}_clouds
+      Clouds: &{{observation_from_jcb}}_clouds
 
   # Observation Bias Correction (VarBC)
   # -----------------------------------

--- a/observations/atmosphere/amsua_n19.yaml.j2
+++ b/observations/atmosphere/amsua_n19.yaml.j2
@@ -34,7 +34,7 @@
       CoefficientPath: "{{crtm_coefficient_path}}"
     linear obs operator:
       Absorbers: [H2O, O3]
-      Clouds: &{{observation_from_jcb}}_clouds
+      Clouds: *{{observation_from_jcb}}_clouds
 
   # Observation Bias Correction (VarBC)
   # -----------------------------------

--- a/observations/atmosphere/amsua_n19.yaml.j2
+++ b/observations/atmosphere/amsua_n19.yaml.j2
@@ -32,6 +32,8 @@
       Sensor_ID: &{{observation_from_jcb}}_sensor_id amsua_n19
       EndianType: little_endian
       CoefficientPath: "{{crtm_coefficient_path}}"
+    linear obs operator:
+      Absorbers: [H2O, O3]
 
   # Observation Bias Correction (VarBC)
   # -----------------------------------


### PR DESCRIPTION
This PR adds extra hydrometeors to the `state variables` processed in variational and local ensemble atmospheric DA.  A missing `linear obs operator` section is also added to `amsua_n19.yaml.j2`.

Resolves #108