### PR TITLE
update interpolation section of gsibec templates

### DIFF
--- a/model/atmosphere/atmosphere_background_error_hybrid_gsibec_bump.yaml.j2
+++ b/model/atmosphere/atmosphere_background_error_hybrid_gsibec_bump.yaml.j2
@@ -18,7 +18,7 @@ components:
         custom grid matching gsi:
           type: gaussian
           lats: {{ atmosphere_npy_ges + 1 }}
-	  {% set lons_val = (atmosphere_npx_ges - 1) * 2 %}
+          {% set lons_val = (atmosphere_npx_ges - 1) * 2 %}
           lons: {{ lons_val }}
         custom partitioner matching gsi:
           bands: {{ atmosphere_layout_gsib_y }}

--- a/model/atmosphere/atmosphere_background_error_hybrid_gsibec_bump.yaml.j2
+++ b/model/atmosphere/atmosphere_background_error_hybrid_gsibec_bump.yaml.j2
@@ -12,13 +12,20 @@ components:
         processor layout y direction: {{atmosphere_layout_gsib_y}}
         debugging mode: false
     saber outer blocks:
-    - saber block name: gsi interpolation to model grid
-      gsi akbk: {{atmosphere_fv3jedi_files_path}}/akbk.nc4
-      gsi error covariance file: {{atmosphere_gsibec_path}}/gsi-coeffs-gfs-global.nc4
-      gsi berror namelist file: {{atmosphere_gsibec_path}}/gfs_gsi_global.nml
-      processor layout x direction: {{atmosphere_layout_gsib_x}}
-      processor layout y direction: {{atmosphere_layout_gsib_y}}
-      debugging mode: false
+    - saber block name: interpolation
+      inner geometry:
+        function space: StructuredColumns
+        custom grid matching gsi:
+          type: gaussian
+          lats: {{ atmosphere_npy_ges + 1 }}
+          lons: {{ (atmosphere_npx_ges - 1) * 2 }}
+        custom partitioner matching gsi:
+          bands: {{ atmosphere_layout_gsib_y }}
+        halo: 1
+      forward interpolator:
+        local interpolator type: oops unstructured grid interpolator
+      inverse interpolator:
+        local interpolator type: oops unstructured grid interpolator
       state variables to inverse: [eastward_wind,northward_wind,air_temperature,air_pressure_at_surface,
                                    water_vapor_mixing_ratio_wrt_moist_air,cloud_liquid_ice,cloud_liquid_water,
                                    ozone_mass_mixing_ratio]

--- a/model/atmosphere/atmosphere_background_error_hybrid_gsibec_bump.yaml.j2
+++ b/model/atmosphere/atmosphere_background_error_hybrid_gsibec_bump.yaml.j2
@@ -18,7 +18,8 @@ components:
         custom grid matching gsi:
           type: gaussian
           lats: {{ atmosphere_npy_ges + 1 }}
-          lons: {{ ( atmosphere_npx_ges - 1 ) * 2 }}
+	  {% set lons_val = (atmosphere_npx_ges - 1) * 2 %}
+          lons: {{ lons_val }}
         custom partitioner matching gsi:
           bands: {{ atmosphere_layout_gsib_y }}
         halo: 1

--- a/model/atmosphere/atmosphere_background_error_hybrid_gsibec_bump.yaml.j2
+++ b/model/atmosphere/atmosphere_background_error_hybrid_gsibec_bump.yaml.j2
@@ -18,8 +18,8 @@ components:
         custom grid matching gsi:
           type: gaussian
           lats: {{ atmosphere_npy_ges + 1 }}
-          {% set lons_val = (atmosphere_npx_ges - 1) * 2 %}
-          lons: {{ lons_val }}
+          {% set atmosphere_lons = (atmosphere_npx_ges - 1) * 2 %}
+          lons: {{ atmosphere_lons }}
         custom partitioner matching gsi:
           bands: {{ atmosphere_layout_gsib_y }}
         halo: 1

--- a/model/atmosphere/atmosphere_background_error_hybrid_gsibec_bump.yaml.j2
+++ b/model/atmosphere/atmosphere_background_error_hybrid_gsibec_bump.yaml.j2
@@ -18,7 +18,7 @@ components:
         custom grid matching gsi:
           type: gaussian
           lats: {{ atmosphere_npy_ges + 1 }}
-          lons: {{ (atmosphere_npx_ges - 1) * 2 }}
+          lons: {{ ( atmosphere_npx_ges - 1 ) * 2 }}
         custom partitioner matching gsi:
           bands: {{ atmosphere_layout_gsib_y }}
         halo: 1

--- a/model/atmosphere/atmosphere_background_error_static_gsibec.yaml.j2
+++ b/model/atmosphere/atmosphere_background_error_static_gsibec.yaml.j2
@@ -16,8 +16,8 @@ saber outer blocks:
     custom grid matching gsi:
       type: gaussian
       lats: {{ atmosphere_npy_ges + 1 }}
-      {% set lons_val = (atmosphere_npx_ges - 1) * 2 %}
-      lons: {{ lons_val }}
+      {% set atmosphere_lons = (atmosphere_npx_ges - 1) * 2 %}
+      lons: {{ atmosphere_lons }}
     custom partitioner matching gsi:
       bands: {{ atmosphere_layout_gsib_y }}
     halo: 1

--- a/model/atmosphere/atmosphere_background_error_static_gsibec.yaml.j2
+++ b/model/atmosphere/atmosphere_background_error_static_gsibec.yaml.j2
@@ -10,13 +10,20 @@ saber central block:
     processor layout y direction: {{atmosphere_layout_gsib_y}}
     debugging mode: false
 saber outer blocks:
-- saber block name: gsi interpolation to model grid
-  gsi akbk: {{atmosphere_fv3jedi_files_path}}/akbk.nc4
-  gsi error covariance file: {{atmosphere_gsibec_path}}/gsi-coeffs-gfs-global.nc4
-  gsi berror namelist file: {{atmosphere_gsibec_path}}/gfs_gsi_global.nml
-  processor layout x direction: {{atmosphere_layout_gsib_x}}
-  processor layout y direction: {{atmosphere_layout_gsib_y}}
-  debugging mode: false
+- saber block name: interpolation
+  inner geometry:
+    function space: StructuredColumns
+    custom grid matching gsi:
+      type: gaussian
+      lats: {{ atmosphere_npy_ges + 1 }}
+      lons: {{ (atmosphere_npx_ges - 1) * 2 }}
+    custom partitioner matching gsi:
+      bands: {{ atmosphere_layout_gsib_y }}
+    halo: 1
+  forward interpolator:
+    local interpolator type: oops unstructured grid interpolator
+  inverse interpolator:
+    local interpolator type: oops unstructured grid interpolator
   state variables to inverse: [eastward_wind,northward_wind,air_temperature,air_pressure_at_surface,
                                water_vapor_mixing_ratio_wrt_moist_air,cloud_liquid_ice,cloud_liquid_water,
                                ozone_mass_mixing_ratio]

--- a/model/atmosphere/atmosphere_background_error_static_gsibec.yaml.j2
+++ b/model/atmosphere/atmosphere_background_error_static_gsibec.yaml.j2
@@ -16,7 +16,8 @@ saber outer blocks:
     custom grid matching gsi:
       type: gaussian
       lats: {{ atmosphere_npy_ges + 1 }}
-      lons: {{ ( atmosphere_npx_ges - 1 ) * 2 }}
+      {% set lons_val = (atmosphere_npx_ges - 1) * 2 %}
+      lons: {{ lons_val }}
     custom partitioner matching gsi:
       bands: {{ atmosphere_layout_gsib_y }}
     halo: 1

--- a/model/atmosphere/atmosphere_background_error_static_gsibec.yaml.j2
+++ b/model/atmosphere/atmosphere_background_error_static_gsibec.yaml.j2
@@ -16,7 +16,7 @@ saber outer blocks:
     custom grid matching gsi:
       type: gaussian
       lats: {{ atmosphere_npy_ges + 1 }}
-      lons: {{ (atmosphere_npx_ges - 1) * 2 }}
+      lons: {{ ( atmosphere_npx_ges - 1 ) * 2 }}
     custom partitioner matching gsi:
       bands: {{ atmosphere_layout_gsib_y }}
     halo: 1


### PR DESCRIPTION
The following JCSDA PRs update how gsibec interpolation is preformed.

- saber PR [#1033](https://github.com/JCSDA-internal/saber/pull/1033)
- fv3-jedi PR [#1354](https://github.com/JCSDA-internal/fv3-jedi/pull/1354)

These PRs require updates to jcb-gdas gsibec templates.  This PR contains the necessary updates.  

Resolves #112 
