### PR TITLE
Add fraction of ice to filter out obs with ice presence

### DIFF
--- a/algorithm/snow/fv3jedi_snow_ensmean.yaml.j2
+++ b/algorithm/snow/fv3jedi_snow_ensmean.yaml.j2
@@ -16,7 +16,7 @@ ensemble:
     template:
       datetime: '{{ snow_background_time_iso }}'
       filetype: fms restart
-      state variables: [snodl,vtype,slmsk,orog_filt,stc,sheleg]
+      state variables: [snodl,vtype,slmsk,orog_filt,stc,sheleg,fice]
       datapath: ./bkg/mem%mem%/
       filename_sfcd: '{{ snow_background_time_fv3 }}.sfc_data.nc'
       filename_cplr: '{{ snow_background_time_fv3 }}.coupler.res'

--- a/model/snow/snow_background.yaml.j2
+++ b/model/snow/snow_background.yaml.j2
@@ -2,7 +2,7 @@ datapath: {{ snow_background_path }}
 filetype: fms restart
 skip coupler file: true
 datetime: '{{ snow_background_time_iso }}'
-state variables: [snodl,vtype,slmsk,sheleg,orog_filt]
+state variables: [snodl,vtype,slmsk,sheleg,orog_filt,fice]
 filename_sfcd: '{{ snow_background_time_fv3 }}.sfc_data.nc'
 filename_cplr: '{{ snow_background_time_fv3 }}.coupler.res'
 filename_orog: '{{ snow_orog_prefix }}_oro_data.nc'

--- a/observations/snow/ims_snow.yaml.j2
+++ b/observations/snow/ims_snow.yaml.j2
@@ -41,6 +41,11 @@
         name: GeoVaLs/slmsk
       minvalue: 0.5
       maxvalue: 1.5
+  - filter: Domain Check # land only, no sea ice
+    where:
+    - variable:
+        name: GeoVaLs/fraction_of_ice
+      maxvalue: 0.0
   - filter: RejectList  # no land-ice
     where:
     - variable:

--- a/observations/snow/sfcsno.yaml.j2
+++ b/observations/snow/sfcsno.yaml.j2
@@ -159,6 +159,7 @@
         flag: elevation_bkgdiff
         ignore: rejected observations
       - name: reject
+    # Add inflate error characterized by a function of elevation difference
     - filter: Variable Assignment
       assignments:
       - name: DerivedMetaData/elevation_diff

--- a/observations/snow/sfcsno.yaml.j2
+++ b/observations/snow/sfcsno.yaml.j2
@@ -134,6 +134,11 @@
         flag: invalid_elevation
         ignore: rejected observations
       - name: reject
+    - filter: Domain Check # land only, no sea ice
+      where:
+      - variable:
+          name: GeoVaLs/fraction_of_ice
+        maxvalue: 0.0
     - filter: RejectList  # no land-ice
       where:
       - variable:
@@ -148,12 +153,54 @@
     - filter: Difference Check # elevation check
       reference: MetaData/stationElevation
       value: GeoVaLs/filtered_orography
-      threshold: 200.
+      threshold: 800.
       actions:
       - name: set
         flag: elevation_bkgdiff
         ignore: rejected observations
       - name: reject
+    - filter: Variable Assignment
+      assignments:
+      - name: DerivedMetaData/elevation_diff
+        type: float
+        function:
+          name: ObsFunction/Arithmetic
+          options:
+            variables: [MetaData/stationElevation, GeoVaLs/filtered_orography]
+            coefficients: [1., -1.]
+            total exponent: 2
+            total coefficient: 0.0000015625  #1/(800*800)
+    - filter: Variable Assignment
+      assignments:
+      - name: DerivedMetaData/elevation_diff_exp
+        type: float
+        function:
+          name: ObsFunction/Exponential
+          options:
+            variables: [DerivedMetaData/elevation_diff]
+            coeffA: 1.
+            coeffB: -1.
+            coeffC: 0.
+            coeffD: 1.
+    - filter: Variable Assignment
+      assignments:
+      - name: DerivedMetaData/elevation_diff_exp_inv
+        type: float
+        function:
+          name: ObsFunction/Arithmetic
+          options:
+            variables: [DerivedMetaData/elevation_diff_exp]
+            total exponent: -1.
+    - filter: Perform Action
+      filter variables:
+      - name: totalSnowDepth
+      where:
+      - variable:
+          name: ObsValue/totalSnowDepth
+        minvalue: 0.
+      action:
+        name: inflate error
+        inflation variable: DerivedMetaData/elevation_diff_exp_inv # 2.0
     - filter: BlackList
       where:
       - variable:
@@ -169,6 +216,8 @@
       filter variables:
       - name: totalSnowDepth
       threshold: 6.25
+      absolute threshold: 250
+      bias correction parameter: 1.0
       actions:
       - name: set
         flag: background_check

--- a/observations/snow/snocvr_snow.yaml.j2
+++ b/observations/snow/snocvr_snow.yaml.j2
@@ -131,6 +131,11 @@
         flag: invalid_elevation
         ignore: rejected observations
       - name: reject
+    - filter: Domain Check # land only, no sea ice
+      where:
+      - variable:
+          name: GeoVaLs/fraction_of_ice
+        maxvalue: 0.0
     - filter: RejectList  # no land-ice
       where:
       - variable:
@@ -145,17 +150,61 @@
     - filter: Difference Check # elevation check
       reference: MetaData/stationElevation
       value: GeoVaLs/filtered_orography
-      threshold: 200.
+      threshold: 800.
       actions:
       - name: set
         flag: elevation_bkgdiff
         ignore: rejected observations
       - name: reject
+    - filter: Variable Assignment
+      assignments:
+      - name: DerivedMetaData/elevation_diff
+        type: float
+        function:
+          name: ObsFunction/Arithmetic
+          options:
+            variables: [MetaData/stationElevation, GeoVaLs/filtered_orography]
+            coefficients: [1., -1.]
+            total exponent: 2
+            total coefficient: 0.0000015625  #1/(800*800)
+    - filter: Variable Assignment
+      assignments:
+      - name: DerivedMetaData/elevation_diff_exp
+        type: float
+        function:
+          name: ObsFunction/Exponential
+          options:
+            variables: [DerivedMetaData/elevation_diff]
+            coeffA: 1.
+            coeffB: -1.
+            coeffC: 0.
+            coeffD: 1.
+    - filter: Variable Assignment
+      assignments:
+      - name: DerivedMetaData/elevation_diff_exp_inv
+        type: float
+        function:
+          name: ObsFunction/Arithmetic
+          options:
+            variables: [DerivedMetaData/elevation_diff_exp]
+            total exponent: -1.
+    - filter: Perform Action
+      filter variables:
+      - name: totalSnowDepth
+      where:
+      - variable:
+          name: ObsValue/totalSnowDepth
+        minvalue: 0.
+      action:
+        name: inflate error
+        inflation variable: DerivedMetaData/elevation_diff_exp_inv # 2.0
   obs post filters:
     - filter: Background Check # gross error check
       filter variables:
       - name: totalSnowDepth
       threshold: 6.25
+      absolute threshold: 250
+      bias correction parameter: 1.0
       actions:
       - name: set
         flag: background_check

--- a/observations/snow/snocvr_snow.yaml.j2
+++ b/observations/snow/snocvr_snow.yaml.j2
@@ -156,6 +156,7 @@
         flag: elevation_bkgdiff
         ignore: rejected observations
       - name: reject
+    # Add inflate error characterized by a function of elevation difference
     - filter: Variable Assignment
       assignments:
       - name: DerivedMetaData/elevation_diff


### PR DESCRIPTION
This PR adds the fraction of ice to filter out the observations if ice is present, because the increments are keeping to be added at locations with persistent positive O-F.

This PR also adds error inflation to station observations (sfcsno and snocvr) from @tsga 