### PR TITLE
Bugfixes for marine yamls

### DIFF
--- a/observations/marine/insitu_profile_bathy.yaml.j2
+++ b/observations/marine/insitu_profile_bathy.yaml.j2
@@ -9,7 +9,7 @@
         type: H5File
         obsfile: "{{marine_obsdataout_path}}/{{marine_obsdataout_prefix}}{{observation_from_jcb}}{{marine_obsdataout_suffix}}"
     simulated variables: [waterTemperature]
-    observed variable: [waterTemperature]
+    observed variables: [waterTemperature]
     io pool:
       max pool size: 1
   obs operator:

--- a/observations/marine/insitu_salt_profile_argo.yaml.j2
+++ b/observations/marine/insitu_salt_profile_argo.yaml.j2
@@ -31,6 +31,7 @@
   # The QC filters used here are based on the document by IODE that can be found at
   # https://cdn.ioos.noaa.gov/media/2017/12/recommendations_in_situ_data_real_time_qc.pdf
   #-------------------------------------------------------------------------------
+
   obs filters:
 
     # land check
@@ -45,6 +46,7 @@
     #-----------------------------------------------------------------------------
     ### Global range test
     #-----------------------------------------------------------------------------
+  
     - filter: Bounds Check
       filter variables: [{name: salinity}]
       minvalue: 2.0
@@ -123,6 +125,7 @@
 
     #### Northwestern shelves
     #-----------------------------------------------------------------------------
+  
     - filter: Bounds Check
       filter variables: [{name: salinity}]
       minvalue: 0.0
@@ -139,6 +142,7 @@
 
     #### Southwestern shelves
     #-----------------------------------------------------------------------------
+  
     - filter: Bounds Check
       filter variables: [{name: salinity}]
       minvalue: 0.0
@@ -155,6 +159,7 @@
 
     #### Arctic Ocean
     #-----------------------------------------------------------------------------
+  
     - filter: Bounds Check
       filter variables: [{name: salinity}]
       minvalue: 2.0
@@ -168,6 +173,17 @@
       filter variables: [{name: salinity}]
       threshold: 5.0
       absolute threshold: 5.0
+
+    - filter: Perform Action
+      action:
+        name: assign error
+        error function:
+          name: ObsFunction/LinearCombination
+          options:
+            variables:
+            - ObsError/salinity
+            coefs:
+            - 1000.0
 
   obs localizations:
   - localization method: Rossby

--- a/observations/marine/insitu_temp_profile_argo.yaml.j2
+++ b/observations/marine/insitu_temp_profile_argo.yaml.j2
@@ -27,6 +27,7 @@
   # The QC filters used here are based on the document by IODE that can be found at
   # https://cdn.ioos.noaa.gov/media/2017/12/recommendations_in_situ_data_real_time_qc.pdf
   #-------------------------------------------------------------------------------
+
   obs filters:
 
     # land check
@@ -41,6 +42,7 @@
     #-------------------------------------------------------------------------------
     ### Global range test
     #-----------------------------------------------------------------------------
+
     - filter: Bounds Check
       filter variables: [{name: waterTemperature}]
       minvalue: -2.5
@@ -119,6 +121,7 @@
 
     #### Northwestern shelves
     #-----------------------------------------------------------------------------
+
     - filter: Bounds Check
       filter variables: [{name: waterTemperature}]
       minvalue: -2.0
@@ -132,8 +135,10 @@
           name: MetaData/longitude
         minvalue: -20
         maxvalue: 10
+
     #### Southwestern shelves
     #-----------------------------------------------------------------------------
+
     - filter: Bounds Check
       filter variables: [{name: waterTemperature}]
       minvalue: -2.0
@@ -150,6 +155,7 @@
 
     #### Arctic Ocean
     #-----------------------------------------------------------------------------
+    
     - filter: Bounds Check
       filter variables: [{name: waterTemperature}]
       minvalue: -1.92
@@ -163,6 +169,17 @@
       filter variables: [{name: waterTemperature}]
       threshold: 5.0
       absolute threshold: 5.0
+
+    - filter: Perform Action
+      action:
+        name: assign error
+        error function:
+          name: ObsFunction/LinearCombination
+          options:
+            variables:
+            - ObsError/waterTemperature
+            coefs:
+            - 1000.0
 
   obs localizations:
   - localization method: Rossby

--- a/observations/marine/sst_abi_g16_l3c.yaml.j2
+++ b/observations/marine/sst_abi_g16_l3c.yaml.j2
@@ -1,1 +1,1 @@
-sst_generic.yaml.j2
+sst_generic_geo.yaml.j2

--- a/observations/marine/sst_abi_g17_l3c.yaml.j2
+++ b/observations/marine/sst_abi_g17_l3c.yaml.j2
@@ -1,1 +1,1 @@
-sst_generic.yaml.j2
+sst_generic_geo.yaml.j2

--- a/observations/marine/sst_ahi_h08_l3c.yaml.j2
+++ b/observations/marine/sst_ahi_h08_l3c.yaml.j2
@@ -1,1 +1,1 @@
-sst_generic.yaml.j2
+sst_generic_geo.yaml.j2

--- a/observations/marine/sst_generic_geo.yaml.j2
+++ b/observations/marine/sst_generic_geo.yaml.j2
@@ -54,6 +54,13 @@
     min value: 200.0e3
     max value: 900.0e3
 {% endif %}
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: GeoVaLs/sea_surface_temperature}
+      maxvalue: -4.0
+
 
   obs post filters:
   - filter: Perform Action  # Pamlico Sound & Chesapeake Bay


### PR DESCRIPTION
This PR implements several bugfixes and typo corrections in the marine yamls:

1. The error coefficients are added back to both Argo yamls
2. The background check post filter in the sst_generic yamls is removed
3. A sst_generic_geo.yaml.j2 file is created to place the geostationary SST retrievals in monitoring mode
