### PR TITLE
Add snocvr obs entry for realtime parallel experiments and operations

### DIFF
--- a/algorithm/snow/snow_obs_staging.yaml.j2
+++ b/algorithm/snow/snow_obs_staging.yaml.j2
@@ -5,9 +5,9 @@ copy_opt:
       {% if use_observer(observation_from_jcb) %}
         {% if not observation_from_jcb == 'ims_snow' %}
         # skip if ims_snow since it is special
-          {% if observation_from_jcb == 'snocvr_snow' %}
-          # snocvr_snow is a .nc file, TODO rename this eventually?
-    - ['{{snow_obsdataroot_path}}/{{snow_obsdatain_prefix}}{{observation_from_jcb}}.nc4', '{{snow_obsdatain_path}}']
+          {% if observation_from_jcb == 'madis_snow' %}
+          # madis_snow is a .nc file with filename 'snocvr_snow' in global GDA.
+    - ['{{snow_obsdataroot_path}}/{{snow_obsdatain_prefix}}snocvr_snow.nc4', '{{snow_obsdatain_path}}']
           {% else %}
     - ['{{snow_obsdataroot_path}}/{{snow_obsdatain_prefix}}{{observation_from_jcb}}{{snow_obsdatain_suffix}}', '{{snow_obsdatain_path}}']
           {% endif %}

--- a/observation_chronicle/snow/t00z/madis_snow.yaml
+++ b/observation_chronicle/snow/t00z/madis_snow.yaml
@@ -1,0 +1,15 @@
+# Instrument metadata
+# -------------------
+commissioned: 2021-01-01T00:00:00
+decommissioned: 2023-05-31T18:00:00
+
+observer_type: conventional  # Type of chronicle to use
+
+window_option: max
+
+# observation type initial configuration
+# --------------------------------
+stations_to_reject: [fakelist]
+
+# Chronicle of changes for this observation type
+# ----------------------------------------

--- a/observation_chronicle/snow/t00z/snocvr.yaml
+++ b/observation_chronicle/snow/t00z/snocvr.yaml
@@ -1,0 +1,14 @@
+# Instrument metadata
+# -------------------
+commissioned: 2023-06-01T00:00:00
+
+observer_type: conventional  # Type of chronicle to use
+
+window_option: max
+
+# observation type initial configuration
+# --------------------------------
+stations_to_reject: [fakelist]
+
+# Chronicle of changes for this observation type
+# ----------------------------------------

--- a/observation_chronicle/snow/t06z/madis_snow.yaml
+++ b/observation_chronicle/snow/t06z/madis_snow.yaml
@@ -1,0 +1,15 @@
+# Instrument metadata
+# -------------------
+commissioned: 2021-01-01T06:00:00
+decommissioned: 2023-05-31T18:00:00
+
+observer_type: conventional  # Type of chronicle to use
+
+window_option: max
+
+# observation type initial configuration
+# --------------------------------
+stations_to_reject: [fakelist]
+
+# Chronicle of changes for this observation type
+# ----------------------------------------

--- a/observation_chronicle/snow/t06z/snocvr.yaml
+++ b/observation_chronicle/snow/t06z/snocvr.yaml
@@ -1,0 +1,14 @@
+# Instrument metadata
+# -------------------
+commissioned: 2023-06-01T06:00:00
+
+observer_type: conventional  # Type of chronicle to use
+
+window_option: max
+
+# observation type initial configuration
+# --------------------------------
+stations_to_reject: [fakelist]
+
+# Chronicle of changes for this observation type
+# ----------------------------------------

--- a/observations/snow/madis_snow.yaml.j2
+++ b/observations/snow/madis_snow.yaml.j2
@@ -3,12 +3,11 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: adpsfc_snow
+    name: madis_snow
     obsdatain:
       engine:
-        type: bufr
-        obsfile: "{{snow_obsdatain_path}}/{{snow_obsdatain_prefix}}{{observation_from_jcb}}{{snow_obsdatain_suffix}}"
-        mapping file: "{{snow_obsdatain_path}}/bufr_adpsfc_mapping.yaml"
+        type: H5File
+        obsfile: "{{snow_obsdatain_path}}/{{snow_obsdatain_prefix}}snocvr_snow.nc4"
         missing file action: warn
       obsgrouping:
         group variables: [stationIdentification]
@@ -50,8 +49,6 @@
       - name: landice_check
         initial value: false
       - name: elevation_bkgdiff
-        initial value: false
-      - name: rejectlist
         initial value: false
       - name: background_check
         initial value: false
@@ -152,16 +149,6 @@
       actions:
       - name: set
         flag: elevation_bkgdiff
-        ignore: rejected observations
-      - name: reject
-    - filter: BlackList
-      where:
-      - variable:
-          name: MetaData/stationIdentification
-        is_in: {{ get_conventional_rejected_stations(observation_from_jcb) }}
-      actions:
-      - name: set
-        flag: rejectlist
         ignore: rejected observations
       - name: reject
   obs post filters:

--- a/observations/snow/sfcsno.yaml.j2
+++ b/observations/snow/sfcsno.yaml.j2
@@ -7,7 +7,7 @@
     obsdatain:
       engine:
         type: bufr
-        obsfile: "{{snow_obsdatain_path}}/{{snow_obsdatain_prefix}}sfcsno.tm00.bufr_d"
+        obsfile: "{{snow_obsdatain_path}}/{{snow_obsdatain_prefix}}{{observation_from_jcb}}{{snow_obsdatain_suffix}}"
         mapping file: "{{snow_obsdatain_path}}/bufr_sfcsno_mapping.yaml"
         missing file action: warn
       obsgrouping:
@@ -15,7 +15,7 @@
     obsdataout:
       engine:
         type: H5File
-        obsfile: "{{snow_obsdataout_path}}/{{snow_obsdataout_prefix}}sfcsno{{snow_obsdataout_suffix}}"
+        obsfile: "{{snow_obsdataout_path}}/{{snow_obsdataout_prefix}}{{observation_from_jcb}}{{snow_obsdataout_suffix}}"
     simulated variables: [totalSnowDepth]
   #
 

--- a/observations/snow/snocvr.yaml.j2
+++ b/observations/snow/snocvr.yaml.j2
@@ -3,12 +3,12 @@
   # Observation Space (I/O)
   # -----------------------
   obs space:
-    name: adpsfc_snow
+    name: snocvr
     obsdatain:
       engine:
         type: bufr
         obsfile: "{{snow_obsdatain_path}}/{{snow_obsdatain_prefix}}{{observation_from_jcb}}{{snow_obsdatain_suffix}}"
-        mapping file: "{{snow_obsdatain_path}}/bufr_adpsfc_mapping.yaml"
+        mapping file: "{{snow_obsdatain_path}}/bufr_snocvr_mapping.yaml"
         missing file action: warn
       obsgrouping:
         group variables: [stationIdentification]
@@ -50,8 +50,6 @@
       - name: landice_check
         initial value: false
       - name: elevation_bkgdiff
-        initial value: false
-      - name: rejectlist
         initial value: false
       - name: background_check
         initial value: false
@@ -134,6 +132,11 @@
         flag: invalid_elevation
         ignore: rejected observations
       - name: reject
+    - filter: Domain Check # land only, no sea ice
+      where:
+      - variable:
+          name: GeoVaLs/fraction_of_ice
+        maxvalue: 0.0
     - filter: RejectList  # no land-ice
       where:
       - variable:
@@ -148,27 +151,62 @@
     - filter: Difference Check # elevation check
       reference: MetaData/stationElevation
       value: GeoVaLs/filtered_orography
-      threshold: 200.
+      threshold: 800.
       actions:
       - name: set
         flag: elevation_bkgdiff
         ignore: rejected observations
       - name: reject
-    - filter: BlackList
+    # Add inflate error characterized by a function of elevation difference
+    - filter: Variable Assignment
+      assignments:
+      - name: DerivedMetaData/elevation_diff
+        type: float
+        function:
+          name: ObsFunction/Arithmetic
+          options:
+            variables: [MetaData/stationElevation, GeoVaLs/filtered_orography]
+            coefficients: [1., -1.]
+            total exponent: 2
+            total coefficient: 0.0000015625  #1/(800*800)
+    - filter: Variable Assignment
+      assignments:
+      - name: DerivedMetaData/elevation_diff_exp
+        type: float
+        function:
+          name: ObsFunction/Exponential
+          options:
+            variables: [DerivedMetaData/elevation_diff]
+            coeffA: 1.
+            coeffB: -1.
+            coeffC: 0.
+            coeffD: 1.
+    - filter: Variable Assignment
+      assignments:
+      - name: DerivedMetaData/elevation_diff_exp_inv
+        type: float
+        function:
+          name: ObsFunction/Arithmetic
+          options:
+            variables: [DerivedMetaData/elevation_diff_exp]
+            total exponent: -1.
+    - filter: Perform Action
+      filter variables:
+      - name: totalSnowDepth
       where:
       - variable:
-          name: MetaData/stationIdentification
-        is_in: {{ get_conventional_rejected_stations(observation_from_jcb) }}
-      actions:
-      - name: set
-        flag: rejectlist
-        ignore: rejected observations
-      - name: reject
+          name: ObsValue/totalSnowDepth
+        minvalue: 0.
+      action:
+        name: inflate error
+        inflation variable: DerivedMetaData/elevation_diff_exp_inv # 2.0
   obs post filters:
     - filter: Background Check # gross error check
       filter variables:
       - name: totalSnowDepth
       threshold: 6.25
+      absolute threshold: 250
+      bias correction parameter: 1.0
       actions:
       - name: set
         flag: background_check


### PR DESCRIPTION
This PR renames the current `snocvr` to `madis` showing the data source for the retrospective experiments, and adds GTS based `snocvr` obs entry for JEDI based snow DA in real-time parallels and operations. 

This PR also adds the `observation_chronicle` to control the start/end time of the observations from `madis_snow` and `snocvr` for the US snow data. 

This PR contributes to https://github.com/NOAA-EMC/GDASApp/pull/1675

This PR resolves https://github.com/NOAA-EMC/GDASApp/issues/1663