### PR TITLE
Fix aero ioda-stats YAMLs

### DIFF
--- a/algorithm/obstats/aero/viirs_n20_template.yaml.j2
+++ b/algorithm/obstats/aero/viirs_n20_template.yaml.j2
@@ -1,5 +1,5 @@
 - obs space:
-    name: aod
+    name: aod_n20
     obsdatain:
       engine:
         type: H5File
@@ -11,6 +11,8 @@
   qc groups: ['EffectiveQC0', 'EffectiveQC1']
   statistics to compute: ['mean', 'count', 'RMS']
   output file: "{{ obspace }}_{{ stat_current_cycle_YMDH }}_output_aod.nc"
+  regular grid binning:
+    bin size in degrees: 1.0
   domains to process:
   - domain:
       name: "SH"

--- a/algorithm/obstats/aero/viirs_n20_template.yaml.j2
+++ b/algorithm/obstats/aero/viirs_n20_template.yaml.j2
@@ -12,7 +12,8 @@
   statistics to compute: ['mean', 'count', 'RMS']
   output file: "{{ obspace }}_{{ stat_current_cycle_YMDH }}_output_aod.nc"
   regular grid binning:
-    bin size in degrees: 1.0
+    bin size in degrees: 5.0
+    use negative longitudes: true 
   domains to process:
   - domain:
       name: "SH"

--- a/algorithm/obstats/aero/viirs_n21_template.yaml.j2
+++ b/algorithm/obstats/aero/viirs_n21_template.yaml.j2
@@ -1,16 +1,18 @@
 - obs space:
-    name: ims_snow
+    name: aod_n21
     obsdatain:
       engine:
         type: H5File
-        obsfile: {{ snow_obsdatain_path }}/snow/diag_{{ obspace }}_{{ stat_current_cycle_YMDH }}.nc
-    simulated variables: ['totalSnowDepth']
-    observed variables: ['totalSnowDepth']
-  statistics to compute: ['mean', 'count', 'RMS']
-  variables: [totalSnowDepth]
+        obsfile: {{ aero_obsdatain_path }}/aero/diag_{{ obspace }}_aod_{{ stat_current_cycle_YMDH }}.nc
+    simulated variables: ['aerosolOpticalDepth']
+    observed variables: ['aerosolOpticalDepth']
+  variables: ['aerosolOpticalDepth']
   groups to process: ['ombg', 'oman']
   qc groups: ['EffectiveQC0', 'EffectiveQC1']
-  output file: "{{ obspace }}_{{ stat_current_cycle_YMDH }}_output_snow.nc"
+  statistics to compute: ['mean', 'count', 'RMS']
+  output file: "{{ obspace }}_{{ stat_current_cycle_YMDH }}_output_aod.nc"
+  regular grid binning:
+    bin size in degrees: 1.0
   domains to process:
   - domain:
       name: "SH"

--- a/algorithm/obstats/aero/viirs_n21_template.yaml.j2
+++ b/algorithm/obstats/aero/viirs_n21_template.yaml.j2
@@ -12,7 +12,8 @@
   statistics to compute: ['mean', 'count', 'RMS']
   output file: "{{ obspace }}_{{ stat_current_cycle_YMDH }}_output_aod.nc"
   regular grid binning:
-    bin size in degrees: 1.0
+    bin size in degrees: 5.0
+    use negative longitudes: true 
   domains to process:
   - domain:
       name: "SH"

--- a/algorithm/obstats/aero/viirs_npp_template.yaml.j2
+++ b/algorithm/obstats/aero/viirs_npp_template.yaml.j2
@@ -1,5 +1,5 @@
 - obs space:
-    name: aod
+    name: aod_npp
     obsdatain:
       engine:
         type: H5File
@@ -11,6 +11,8 @@
   qc groups: ['EffectiveQC0', 'EffectiveQC1']
   statistics to compute: ['mean', 'count', 'RMS']
   output file: "{{ obspace }}_{{ stat_current_cycle_YMDH }}_output_aod.nc"
+  regular grid binning:
+    bin size in degrees: 1.0
   domains to process:
   - domain:
       name: "SH"

--- a/algorithm/obstats/aero/viirs_npp_template.yaml.j2
+++ b/algorithm/obstats/aero/viirs_npp_template.yaml.j2
@@ -12,7 +12,8 @@
   statistics to compute: ['mean', 'count', 'RMS']
   output file: "{{ obspace }}_{{ stat_current_cycle_YMDH }}_output_aod.nc"
   regular grid binning:
-    bin size in degrees: 1.0
+    bin size in degrees: 5.0
+    use negative longitudes: true 
   domains to process:
   - domain:
       name: "SH"


### PR DESCRIPTION
The aerosol obs spaces were -180 to 180 for longitude, the ioda-stats code couldn't handle this, now this can be configured by a YAML option.