### PR TITLE
Revise IMS ioda-stats YAML and add other snow stats YAMLs

### DIFF
--- a/algorithm/obstats/snow/ims_snow_template.yaml.j2
+++ b/algorithm/obstats/snow/ims_snow_template.yaml.j2
@@ -11,6 +11,9 @@
   groups to process: ['ombg', 'oman']
   qc groups: ['EffectiveQC0', 'EffectiveQC1']
   output file: "{{ obspace }}_{{ stat_current_cycle_YMDH }}_output_snow.nc"
+  regular grid binning:
+    bin size in degrees: 2.0
+    use negative longitudes: false 
   domains to process:
   - domain:
       name: "SH"
@@ -21,26 +24,45 @@
       first mask variable: latitude
       first mask range: [0,90]
   - domain:
-      name: "CONUS"
+      name: "West_CONUS"
       first mask variable: latitude
       first mask range: [25,49]
       second mask variable: longitude
-      second mask range: [-125,-66]
+      second mask range: [235,260]
+  - domain:
+      name: "East_CONUS"
+      first mask variable: latitude
+      first mask range: [25,49]
+      second mask variable: longitude
+      second mask range: [260,294]
+  - domain:
+      name: "Alaska"
+      first mask variable: latitude
+      first mask range: [52,72]
+      second mask variable: longitude
+      second mask range: [190,230]
   - domain:
       name: "Europe"
       first mask variable: latitude
       first mask range: [35,70]
       second mask variable: longitude
-      second mask range: [-11,38]
+      second mask range: [38,349]
   - domain:
       name: "Africa"
       first mask variable: latitude
       first mask range: [-35,37]
       second mask variable: longitude
-      second mask range: [-17,52]
+      second mask range: [52,343]
   - domain:
       name: "Asia"
       first mask variable: latitude
       first mask range: [0,70]
       second mask variable: longitude
       second mask range: [38, 180]
+   - domain:
+      name: "High_Mount_Asia"
+      first mask variable: latitude
+      first mask range: [20,46]
+      second mask variable: longitude
+      second mask range: [60, 111]
+

--- a/algorithm/obstats/snow/ims_snow_template.yaml.j2
+++ b/algorithm/obstats/snow/ims_snow_template.yaml.j2
@@ -59,7 +59,7 @@
       first mask range: [0,70]
       second mask variable: longitude
       second mask range: [38, 180]
-   - domain:
+  - domain:
       name: "High_Mount_Asia"
       first mask variable: latitude
       first mask range: [20,46]

--- a/algorithm/obstats/snow/sfcsno_template.yaml.j2
+++ b/algorithm/obstats/snow/sfcsno_template.yaml.j2
@@ -1,0 +1,68 @@
+- obs space:
+    name: sfcsno
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: {{ snow_obsdatain_path }}/snow/diag_{{ obspace }}_{{ stat_current_cycle_YMDH }}.nc
+    simulated variables: ['totalSnowDepth']
+    observed variables: ['totalSnowDepth']
+  statistics to compute: ['mean', 'count', 'RMS']
+  variables: [totalSnowDepth]
+  groups to process: ['ombg', 'oman']
+  qc groups: ['EffectiveQC0', 'EffectiveQC1']
+  output file: "{{ obspace }}_{{ stat_current_cycle_YMDH }}_output_snow.nc"
+  regular grid binning:
+    bin size in degrees: 1.0
+    use negative longitudes: true 
+  domains to process:
+  - domain:
+      name: "SH"
+      first mask variable: latitude
+      first mask range: [-90,0]
+  - domain:
+      name: "NH"
+      first mask variable: latitude
+      first mask range: [0,90]
+  - domain:
+      name: "West_CONUS"
+      first mask variable: latitude
+      first mask range: [25,49]
+      second mask variable: longitude
+      second mask range: [-125,-100]
+  - domain:
+      name: "East_CONUS"
+      first mask variable: latitude
+      first mask range: [25,49]
+      second mask variable: longitude
+      second mask range: [-100,-66]
+  - domain:
+      name: "Alaska"
+      first mask variable: latitude
+      first mask range: [52,72]
+      second mask variable: longitude
+      second mask range: [-170,-130]
+  - domain:
+      name: "Europe"
+      first mask variable: latitude
+      first mask range: [35,70]
+      second mask variable: longitude
+      second mask range: [-11,38]
+  - domain:
+      name: "Africa"
+      first mask variable: latitude
+      first mask range: [-35,37]
+      second mask variable: longitude
+      second mask range: [-17,52]
+  - domain:
+      name: "Asia"
+      first mask variable: latitude
+      first mask range: [0,70]
+      second mask variable: longitude
+      second mask range: [38, 180]
+  - domain:
+      name: "High_Mount_Asia"
+      first mask variable: latitude
+      first mask range: [20,46]
+      second mask variable: longitude
+      second mask range: [60, 111]
+

--- a/algorithm/obstats/snow/snocvr_snow_template.yaml.j2
+++ b/algorithm/obstats/snow/snocvr_snow_template.yaml.j2
@@ -1,0 +1,68 @@
+- obs space:
+    name: snocvr_snow
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: {{ snow_obsdatain_path }}/snow/diag_{{ obspace }}_{{ stat_current_cycle_YMDH }}.nc
+    simulated variables: ['totalSnowDepth']
+    observed variables: ['totalSnowDepth']
+  statistics to compute: ['mean', 'count', 'RMS']
+  variables: [totalSnowDepth]
+  groups to process: ['ombg', 'oman']
+  qc groups: ['EffectiveQC0', 'EffectiveQC1']
+  output file: "{{ obspace }}_{{ stat_current_cycle_YMDH }}_output_snow.nc"
+  regular grid binning:
+    bin size in degrees: 1.0
+    use negative longitudes: true 
+  domains to process:
+  - domain:
+      name: "SH"
+      first mask variable: latitude
+      first mask range: [-90,0]
+  - domain:
+      name: "NH"
+      first mask variable: latitude
+      first mask range: [0,90]
+  - domain:
+      name: "West_CONUS"
+      first mask variable: latitude
+      first mask range: [25,49]
+      second mask variable: longitude
+      second mask range: [-125,-100]
+  - domain:
+      name: "East_CONUS"
+      first mask variable: latitude
+      first mask range: [25,49]
+      second mask variable: longitude
+      second mask range: [-100,-66]
+  - domain:
+      name: "Alaska"
+      first mask variable: latitude
+      first mask range: [52,72]
+      second mask variable: longitude
+      second mask range: [-170,-130]
+  - domain:
+      name: "Europe"
+      first mask variable: latitude
+      first mask range: [35,70]
+      second mask variable: longitude
+      second mask range: [-11,38]
+  - domain:
+      name: "Africa"
+      first mask variable: latitude
+      first mask range: [-35,37]
+      second mask variable: longitude
+      second mask range: [-17,52]
+  - domain:
+      name: "Asia"
+      first mask variable: latitude
+      first mask range: [0,70]
+      second mask variable: longitude
+      second mask range: [38, 180]
+  - domain:
+      name: "High_Mount_Asia"
+      first mask variable: latitude
+      first mask range: [20,46]
+      second mask variable: longitude
+      second mask range: [60, 111]
+


### PR DESCRIPTION
This PR directly solves Issue: https://github.com/NOAA-EMC/jcb-gdas/issues/122

Edits made in this PR include:
1) fix a bug in the current IMS ioda-stats YAML since diag_ims file uses longitude from 0 to 360, instead of -180 to 180.
2) add `snocvr_snow.yaml` and  `sfcsno.yaml` for outputing ioda-stats.
3) add other domains of interest to all three snow-related YAMLs per discussions on 05/15/2025 land team meeting.

No significant changes of the output are expected as a result of this PR. Note: the bin size of the ims_snow.yaml is set to 2 deg for now due to run time consideration. 1 deg bin takes a much longer time for ioda-stats.exe to process diag_ims file at a relatively fine resolution (e.g., C384).

A G-W CI test of `C96C48mx500_S2SW_cyc_gfs` was conducted: the concatenated `snow.yaml` looks OK.

Per discussions with David @DavidNew-NOAA (see below), a PR will be submitted to G-W to output snocvr and sfcsno stats.