### PR TITLE
rename "snocvr_snow" to "snocvr"

### DIFF
--- a/algorithm/obstats/snow/madis_snow_template.yaml.j2
+++ b/algorithm/obstats/snow/madis_snow_template.yaml.j2
@@ -1,0 +1,68 @@
+- obs space:
+    name: madis_snow 
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: {{ snow_obsdatain_path }}/snow/diag_{{ obspace }}_{{ stat_current_cycle_YMDH }}.nc
+    simulated variables: ['totalSnowDepth']
+    observed variables: ['totalSnowDepth']
+  statistics to compute: ['mean', 'count', 'RMS']
+  variables: [totalSnowDepth]
+  groups to process: ['ombg', 'oman']
+  qc groups: ['EffectiveQC0', 'EffectiveQC1']
+  output file: "{{ obspace }}_{{ stat_current_cycle_YMDH }}_output_snow.nc"
+  regular grid binning:
+    bin size in degrees: 1.0
+    use negative longitudes: true 
+  domains to process:
+  - domain:
+      name: "SH"
+      first mask variable: latitude
+      first mask range: [-90,0]
+  - domain:
+      name: "NH"
+      first mask variable: latitude
+      first mask range: [0,90]
+  - domain:
+      name: "West_CONUS"
+      first mask variable: latitude
+      first mask range: [25,49]
+      second mask variable: longitude
+      second mask range: [-125,-100]
+  - domain:
+      name: "East_CONUS"
+      first mask variable: latitude
+      first mask range: [25,49]
+      second mask variable: longitude
+      second mask range: [-100,-66]
+  - domain:
+      name: "Alaska"
+      first mask variable: latitude
+      first mask range: [52,72]
+      second mask variable: longitude
+      second mask range: [-170,-130]
+  - domain:
+      name: "Europe"
+      first mask variable: latitude
+      first mask range: [35,70]
+      second mask variable: longitude
+      second mask range: [-11,38]
+  - domain:
+      name: "Africa"
+      first mask variable: latitude
+      first mask range: [-35,37]
+      second mask variable: longitude
+      second mask range: [-17,52]
+  - domain:
+      name: "Asia"
+      first mask variable: latitude
+      first mask range: [0,70]
+      second mask variable: longitude
+      second mask range: [38, 180]
+  - domain:
+      name: "High_Mount_Asia"
+      first mask variable: latitude
+      first mask range: [20,46]
+      second mask variable: longitude
+      second mask range: [60, 111]
+

--- a/algorithm/obstats/snow/snocvr_template.yaml.j2
+++ b/algorithm/obstats/snow/snocvr_template.yaml.j2
@@ -1,5 +1,5 @@
 - obs space:
-    name: snocvr_snow
+    name: snocvr
     obsdatain:
       engine:
         type: H5File


### PR DESCRIPTION
This PR directly addresses the Issue: https://github.com/NOAA-EMC/jcb-gdas/issues/124.

In all, (outdated) "snocvr_snow" = (now) "madis_snow" for use for 2021-2023 observations. "snocvr" is used to denote 2023 to current snocvr observations. Based on conversations with Jiarui, several draft PRs in G-W and GDAS will be submitted to handle the switch among different snocvr names automatically. 

Again, thanks for discussions with Jiarui Dong @jiaruidong2017 for the clarification of the issue!