### PR TITLE
Bugfix for marine obs over model's land

### DIFF
--- a/observations/marine/adt_rads_all.yaml.j2
+++ b/observations/marine/adt_rads_all.yaml.j2
@@ -21,6 +21,7 @@
   - filter: Domain Check
     where:
     - variable: {name: GeoVaLs/sea_area_fraction}
+      value: is_valid
       minvalue: 0.9
   - filter: Domain Check
     where:

--- a/observations/marine/icec_abi_g16_l2.yaml.j2
+++ b/observations/marine/icec_abi_g16_l2.yaml.j2
@@ -22,6 +22,7 @@
   - filter: Domain Check
     where:
     - variable: {name: GeoVaLs/sea_area_fraction}
+      value: is_valid
       minvalue: 0.9
   - filter: Bounds Check
     minvalue: 0.0

--- a/observations/marine/icec_amsr2_north.yaml.j2
+++ b/observations/marine/icec_amsr2_north.yaml.j2
@@ -22,6 +22,7 @@
   - filter: Domain Check
     where:
     - variable: {name: GeoVaLs/sea_area_fraction}
+      value: is_valid
       minvalue: 0.9
   - filter: Bounds Check
     minvalue: 0.0

--- a/observations/marine/icec_amsr2_south.yaml.j2
+++ b/observations/marine/icec_amsr2_south.yaml.j2
@@ -22,6 +22,7 @@
   - filter: Domain Check
     where:
     - variable: {name: GeoVaLs/sea_area_fraction}
+      value: is_valid
       minvalue: 0.9
   - filter: Bounds Check
     minvalue: 0.0

--- a/observations/marine/icec_amsu_mb_l2.yaml.j2
+++ b/observations/marine/icec_amsu_mb_l2.yaml.j2
@@ -22,6 +22,7 @@
   - filter: Domain Check
     where:
     - variable: {name: GeoVaLs/sea_area_fraction}
+      value: is_valid
       minvalue: 0.9
   - filter: Bounds Check
     minvalue: 0.0

--- a/observations/marine/icec_atms_n20_l2.yaml.j2
+++ b/observations/marine/icec_atms_n20_l2.yaml.j2
@@ -22,6 +22,7 @@
   - filter: Domain Check
     where:
     - variable: {name: GeoVaLs/sea_area_fraction}
+      value: is_valid
       minvalue: 0.9
   - filter: Bounds Check
     minvalue: 0.0

--- a/observations/marine/icec_atms_n21_l2.yaml.j2
+++ b/observations/marine/icec_atms_n21_l2.yaml.j2
@@ -22,6 +22,7 @@
   - filter: Domain Check
     where:
     - variable: {name: GeoVaLs/sea_area_fraction}
+      value: is_valid
       minvalue: 0.9
   - filter: Bounds Check
     minvalue: 0.0

--- a/observations/marine/icec_atms_npp_l2.yaml.j2
+++ b/observations/marine/icec_atms_npp_l2.yaml.j2
@@ -22,6 +22,7 @@
   - filter: Domain Check
     where:
     - variable: {name: GeoVaLs/sea_area_fraction}
+      value: is_valid
       minvalue: 0.9
   - filter: Bounds Check
     minvalue: 0.0

--- a/observations/marine/icec_gmi_gpm_l2.yaml.j2
+++ b/observations/marine/icec_gmi_gpm_l2.yaml.j2
@@ -22,6 +22,7 @@
   - filter: Domain Check
     where:
     - variable: {name: GeoVaLs/sea_area_fraction}
+      value: is_valid
       minvalue: 0.9
   - filter: Bounds Check
     minvalue: 0.0

--- a/observations/marine/icec_ssmis_f17_l2.yaml.j2
+++ b/observations/marine/icec_ssmis_f17_l2.yaml.j2
@@ -22,6 +22,7 @@
   - filter: Domain Check
     where:
     - variable: {name: GeoVaLs/sea_area_fraction}
+      value: is_valid
       minvalue: 0.9
   - filter: Bounds Check
     minvalue: 0.0

--- a/observations/marine/icec_viirs_n20_l2_north.yaml.j2
+++ b/observations/marine/icec_viirs_n20_l2_north.yaml.j2
@@ -22,6 +22,7 @@
   - filter: Domain Check
     where:
     - variable: {name: GeoVaLs/sea_area_fraction}
+      value: is_valid
       minvalue: 0.9
   - filter: Bounds Check
     minvalue: 0.0

--- a/observations/marine/icec_viirs_n20_l2_south.yaml.j2
+++ b/observations/marine/icec_viirs_n20_l2_south.yaml.j2
@@ -22,6 +22,7 @@
   - filter: Domain Check
     where:
     - variable: {name: GeoVaLs/sea_area_fraction}
+      value: is_valid
       minvalue: 0.9
   - filter: Bounds Check
     minvalue: 0.0

--- a/observations/marine/insitu_profile_argo.yaml.j2
+++ b/observations/marine/insitu_profile_argo.yaml.j2
@@ -46,6 +46,7 @@
     - filter: Domain Check
       where:
       - variable: {name: GeoVaLs/sea_area_fraction}
+        value: is_valid
         minvalue: 0.5
 
   #-------------------------------------------------------------------------------

--- a/observations/marine/insitu_salt_profile_argo.yaml.j2
+++ b/observations/marine/insitu_salt_profile_argo.yaml.j2
@@ -38,6 +38,7 @@
     - filter: Domain Check
       where:
       - variable: {name: GeoVaLs/sea_area_fraction}
+        value: is_valid
         minvalue: 0.5
 
 

--- a/observations/marine/insitu_temp_profile_argo.yaml.j2
+++ b/observations/marine/insitu_temp_profile_argo.yaml.j2
@@ -34,6 +34,7 @@
     - filter: Domain Check
       where:
       - variable: {name: GeoVaLs/sea_area_fraction}
+        value: is_valid
         minvalue: 0.5
 
   #-------------------------------------------------------------------------------

--- a/observations/marine/sss_smap_l2.yaml.j2
+++ b/observations/marine/sss_smap_l2.yaml.j2
@@ -22,6 +22,7 @@
   - filter: Domain Check
     where:
     - variable: {name: GeoVaLs/sea_area_fraction}
+      value: is_valid
       minvalue: 0.9
   - filter: Bounds Check
     minvalue: 0.1

--- a/observations/marine/sss_smos_l2.yaml.j2
+++ b/observations/marine/sss_smos_l2.yaml.j2
@@ -22,6 +22,7 @@
   - filter: Domain Check
     where:
     - variable: {name: GeoVaLs/sea_area_fraction}
+      value: is_valid
       minvalue: 0.9
   - filter: Bounds Check
     minvalue: 0.1

--- a/observations/marine/sst_generic.yaml.j2
+++ b/observations/marine/sst_generic.yaml.j2
@@ -46,6 +46,7 @@
   - filter: Domain Check
     where:
     - variable: {name: GeoVaLs/sea_area_fraction}
+      value: is_valid
       minvalue: 0.9
   - filter: Domain Check
     where:

--- a/observations/marine/sst_generic_geo.yaml.j2
+++ b/observations/marine/sst_generic_geo.yaml.j2
@@ -46,6 +46,7 @@
   - filter: Domain Check
     where:
     - variable: {name: GeoVaLs/sea_area_fraction}
+      value: is_valid
       minvalue: 0.9
   - filter: Domain Check
     where:


### PR DESCRIPTION
Occasionally, marine observations are surrounded by what model thinks is land. In this case the check for obs over land needs to check whether the mask is defined in addition to checking the mask values. This is fixed here.

Closes https://github.com/NOAA-EMC/GDASApp/issues/1739