### PR TITLE
Save soca_diag_stats yaml with JCB

### DIFF
--- a/algorithm/marine/soca_diags_finalize.yaml.j2
+++ b/algorithm/marine/soca_diags_finalize.yaml.j2
@@ -5,4 +5,4 @@ copy_opt:
 - ['{{marine_obsdataout_path}}/{{marine_obsdatain_prefix}}ocn.{{observation_from_jcb}}.stats.csv', '{{marine_obsdatastats_path}}']
 {% endif %}
 {% endfor %}
-- ['{{marine_output_dir}}/soca_diag_stats.yaml', '{{marine_obsdatastatsyaml_path}}']
+- ['{{marine_output_dir}}/soca_diag_stats.yaml', '{{marine_config_path}}']

--- a/algorithm/marine/soca_diags_finalize.yaml.j2
+++ b/algorithm/marine/soca_diags_finalize.yaml.j2
@@ -5,3 +5,4 @@ copy_opt:
 - ['{{marine_obsdataout_path}}/{{marine_obsdatain_prefix}}ocn.{{observation_from_jcb}}.stats.csv', '{{marine_obsdatastats_path}}']
 {% endif %}
 {% endfor %}
+- ['{{marine_output_dir}}/soca_diag_stats.yaml', '{{marine_obsdatastatsyaml_path}}']


### PR DESCRIPTION
This PR moves the saving of the soca_diag_stats yaml into the JCB template that already saves the obs statistics. 

Issue: https://github.com/NOAA-EMC/GDASApp/issues/1738
Companions PRs: 
https://github.com/NOAA-EMC/GDASApp/pull/1748 
https://github.com/NOAA-EMC/global-workflow/pull/3797