### PR TITLE
Change land_frac threshold

### DIFF
--- a/observations/snow/adpsfc_snow.yaml.j2
+++ b/observations/snow/adpsfc_snow.yaml.j2
@@ -116,7 +116,7 @@
       where:
       - variable:
           name: GeoVaLs/fraction_of_land
-        minvalue: 0.0001
+        minvalue: 0.5
       actions:
       - name: set
         flag: land_check

--- a/observations/snow/ghcn_snow.yaml.j2
+++ b/observations/snow/ghcn_snow.yaml.j2
@@ -38,7 +38,7 @@
       where:
       - variable:
           name: GeoVaLs/fraction_of_land
-        minvalue: 0.0001
+        minvalue: 0.5
     - filter: RejectList  # no land-ice
       where:
       - variable:

--- a/observations/snow/ims_snow.yaml.j2
+++ b/observations/snow/ims_snow.yaml.j2
@@ -39,7 +39,7 @@
     where:
     - variable:
         name: GeoVaLs/fraction_of_land
-      minvalue: 0.0001
+      minvalue: 0.5
   - filter: Domain Check # land only, no sea ice
     where:
     - variable:

--- a/observations/snow/madis_snow.yaml.j2
+++ b/observations/snow/madis_snow.yaml.j2
@@ -115,7 +115,7 @@
       where:
       - variable:
           name: GeoVaLs/fraction_of_land
-        minvalue: 0.0001
+        minvalue: 0.5
       actions:
       - name: set
         flag: land_check

--- a/observations/snow/sfcsno.yaml.j2
+++ b/observations/snow/sfcsno.yaml.j2
@@ -116,7 +116,7 @@
       where:
       - variable:
           name: GeoVaLs/fraction_of_land
-        minvalue: 0.0001
+        minvalue: 0.5
       actions:
       - name: set
         flag: land_check

--- a/observations/snow/snocvr.yaml.j2
+++ b/observations/snow/snocvr.yaml.j2
@@ -116,7 +116,7 @@
       where:
       - variable:
           name: GeoVaLs/fraction_of_land
-        minvalue: 0.0001
+        minvalue: 0.5
       actions:
       - name: set
         flag: land_check


### PR DESCRIPTION
In order to solve the issue outlined in https://github.com/NOAA-EMC/jcb-gdas/issues/147, this PR is intended to have the land_frac threshold to be 0.5 for all snow obs. yamls.