### PR TITLE
Add thinning for ice obs when used in LETKF

### DIFF
--- a/observations/marine/icec_amsr2_north.yaml.j2
+++ b/observations/marine/icec_amsr2_north.yaml.j2
@@ -40,12 +40,14 @@
     action:
       name: inflate error
       inflation factor: 2.0
-#  - filter: Gaussian Thinning
-#    horizontal_mesh: 25  #km
-#    use_reduced_horizontal_grid: true
-#    select_median: true
-#    action:
-#      name: reduce obs space
+{% if letkf_app | default(false) %}
+  - filter: Gaussian Thinning
+    horizontal_mesh: 25  #km
+    use_reduced_horizontal_grid: true
+    select_median: true
+    action:
+      name: reduce obs space
+{% endif %}
 {% if letkf_app | default(false) %}
   obs localizations:
   - localization method: Rossby

--- a/observations/marine/icec_amsr2_south.yaml.j2
+++ b/observations/marine/icec_amsr2_south.yaml.j2
@@ -40,12 +40,14 @@
     action:
       name: inflate error
       inflation factor: 2.0
-#  - filter: Gaussian Thinning
-#    horizontal_mesh: 25  #km
-#    use_reduced_horizontal_grid: true
-#    select_median: true
-#    action:
-#      name: reduce obs space
+{% if letkf_app | default(false) %}
+  - filter: Gaussian Thinning
+    horizontal_mesh: 25  #km
+    use_reduced_horizontal_grid: true
+    select_median: true
+    action:
+      name: reduce obs space
+{% endif %}
 {% if letkf_app | default(false) %}
   obs localizations:
   - localization method: Rossby


### PR DESCRIPTION
Thin AMSR2 ice concentration obs, only for LETKF to avoid messing with gfsv17 configuration.
I ran a test and confirmed that obs are thinned in LETKF, and not thinned in Var.

Note: requires gdas PR to work correctly.