### PR TITLE
Updates for faster recentering

### DIFF
--- a/algorithm/marine/soca_ens_handler.yaml.j2
+++ b/algorithm/marine/soca_ens_handler.yaml.j2
@@ -8,7 +8,6 @@ date: "{{ marine_window_end_iso }}"
 
 layers variable: [sea_water_cell_thickness]
 
-# TODO(AFE) fix ice recentering in cycled da
 increment variables:
 - sea_water_potential_temperature
 - sea_water_salinity
@@ -73,7 +72,7 @@ sea ice variable change:
     sno_lev: 1
   cice output:
     pattern: "%mem%"
-    restart: ens/cice_model.res.output.%mem%.nc
+    restart: ens/cice_model.res.%mem%.nc
   output variables:
   - sea_water_potential_temperature
   - sea_water_salinity
@@ -92,7 +91,6 @@ soca increments:  # Could also be states, but they are read as increments
     read_from_file: 3
 
 trajectory:
-# TODO(AFE) fix ice recentering in cycled da
   state variables:
   - sea_water_potential_temperature
   - sea_water_salinity
@@ -113,10 +111,8 @@ trajectory:
 output increment:
   datadir: ./
   date: "{{ marine_window_end_iso }}"
-  exp: trash
+  exp: recenter
   type: incr
-  output file: "recenter.incr.%mem%.nc"
-  pattern: "%mem%"
 
 ensemble variance output:
   datadir: ./


### PR DESCRIPTION
Faster recentering (short-term solution):
- no extra copies of CICE restarts
- only save recentering increment once from the jedi app: it's the same for all ensemble members
- removed comments about ice recentering: this was done