### PR TITLE
Set background check for AMSR2 sea ice data

### DIFF
--- a/observations/marine/icec_amsr2_north.yaml.j2
+++ b/observations/marine/icec_amsr2_north.yaml.j2
@@ -28,7 +28,7 @@
     minvalue: 0.0
     maxvalue: 1.0
   - filter: Background Check
-      absolute threshold: 0.5
+    absolute threshold: 0.5
   - filter: Domain Check
     where:
     - variable: { name: GeoVaLs/sea_surface_temperature}

--- a/observations/marine/icec_amsr2_north.yaml.j2
+++ b/observations/marine/icec_amsr2_north.yaml.j2
@@ -27,8 +27,8 @@
   - filter: Bounds Check
     minvalue: 0.0
     maxvalue: 1.0
-  #- filter: Background Check
-  #  threshold: 5.0
+  - filter: Background Check
+    absolute threshold: 0.5
   - filter: Domain Check
     where:
     - variable: { name: GeoVaLs/sea_surface_temperature}

--- a/observations/marine/icec_amsr2_north.yaml.j2
+++ b/observations/marine/icec_amsr2_north.yaml.j2
@@ -28,7 +28,7 @@
     minvalue: 0.0
     maxvalue: 1.0
   - filter: Background Check
-    absolute threshold: 0.5
+      absolute threshold: 0.5
   - filter: Domain Check
     where:
     - variable: { name: GeoVaLs/sea_surface_temperature}

--- a/observations/marine/icec_amsr2_south.yaml.j2
+++ b/observations/marine/icec_amsr2_south.yaml.j2
@@ -28,7 +28,7 @@
     minvalue: 0.0
     maxvalue: 1.0
   - filter: Background Check
-      absolute threshold: 0.5
+    absolute threshold: 0.5
   - filter: Domain Check
     where:
     - variable: { name: GeoVaLs/sea_surface_temperature}

--- a/observations/marine/icec_amsr2_south.yaml.j2
+++ b/observations/marine/icec_amsr2_south.yaml.j2
@@ -27,8 +27,8 @@
   - filter: Bounds Check
     minvalue: 0.0
     maxvalue: 1.0
-  #- filter: Background Check
-  #  threshold: 5.0
+  - filter: Background Check
+      absolute threshold: 0.5
   - filter: Domain Check
     where:
     - variable: { name: GeoVaLs/sea_surface_temperature}


### PR DESCRIPTION
Background check to deal with faulty AMSR2 retrievals (e.g. see below the data we're using to generate obs). Background check with absolute threshold should filter out most of this data, and hopefully SST check will filter out the rest. NESDIS is working on a solution for the retrievals.

<img width="1541" height="1893" alt="amsr_19_1" src="https://github.com/user-attachments/assets/6259baa2-9cd9-4019-912d-2f080d0d60e0" />
