### PR TITLE
Make nens per MPI in parallel recentering configurable

### DIFF
--- a/algorithm/marine/soca_ens_handler.yaml.j2
+++ b/algorithm/marine/soca_ens_handler.yaml.j2
@@ -4,7 +4,7 @@ geometry:
   fields metadata: ./fields_metadata.yaml
 
 nens: '{{ marine_number_ensemble_members }}'
-nens per MPI task: 2
+nens per MPI task: '{{ marine_number_ensemble_members_per_mpi }}'
 
 increment variables: &vars
 - sea_water_potential_temperature


### PR DESCRIPTION
This is needed to configure resources correctly for the marine ensemble recentering.