### PR TITLE
Add yamls for select observations to atmosphere-lgetkf

### DIFF
--- a/observations/atmosphere-lgetkf/gnssro_cosmic2.yaml.j2
+++ b/observations/atmosphere-lgetkf/gnssro_cosmic2.yaml.j2
@@ -1,0 +1,104 @@
+-
+
+  # Observation Space (I/O)
+  # -----------------------
+  obs space:
+    name: gnssrobndnbam_cosmic2
+    distribution:
+      name: "{{distribution_type}}"
+      halo size: 1250e3
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdatain_path}}/{{atmosphere_obsdatain_prefix}}{{observation_from_jcb}}{{atmosphere_obsdatain_suffix}}" 
+      obsgrouping:
+        group variables: [ 'sequenceNumber' ]
+        sort variable: 'impactHeightRO'
+        sort order: 'ascending'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"        
+    simulated variables: [bendingAngle]
+
+  # Observation Operator
+  # --------------------
+  obs operator:
+    name: GnssroBndNBAM
+    obs options:
+      use_compress: 1
+      sr_steps: 2
+      vertlayer: full
+      super_ref_qc: NBAM
+      output_diags: true
+
+  # Observation Filters (QC)
+  # ------------------------
+  obs filters:
+  # Apply gross check using pccf
+  # Step 0-A: Create Diagnostic Flags 
+  # Diagnostic flag for pccf
+  - filter: Create Diagnostic Flags
+    filter variables:  
+    - name: bendingAngle 
+    flags:
+    - name: pccfCheckReject
+      initial value: false 
+      force reinitialization: true
+  
+  # Step 0-B: pccf Check for CDACC data  - good: 0.1-100, reject: 0
+  - filter: Bounds Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/satelliteIdentifier
+      is_in: 265-269,750-755,44,786,820,825
+    test variables:
+    - name: MetaData/pccf
+    minvalue: 0.1
+    maxvalue: 100.1
+    actions:
+    - name: set
+      flag: pccfCheckReject
+    - name: reject
+  
+  #1. gpstop
+  - filter: Domain Check
+    filter variables:
+    - name: bendingAngle
+    where:
+    - variable:
+        name: MetaData/impactHeightRO
+      minvalue: 0
+      maxvalue: 55000.1
+    action:
+      name: reject
+  #3. RONBAM cut off check
+  - filter: Background Check RONBAM
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: reject
+    defer to post: true
+  #4. assign obs error 
+  - filter: ROobserror
+    filter variables:
+    - name: bendingAngle
+    errmodel: NBAM
+    defer to post: true
+  #5. Obs error inflate
+  - filter: Perform Action
+    filter variables:
+    - name: bendingAngle
+    action:
+      name: RONBAMErrInflate
+    defer to post: true
+  # --------------------------------
+
+ # Observation Localizations (LocalEnsembleDA)
+ # -------------------------------------------
+  obs localizations:
+  - localization method: Horizontal Gaspari-Cohn
+    lengthscale: 1250e3
+    max obs: 10000

--- a/observations/atmosphere-lgetkf/ozone.ompsnp_npp.yaml.j2
+++ b/observations/atmosphere-lgetkf/ozone.ompsnp_npp.yaml.j2
@@ -1,0 +1,341 @@
+-
+
+  # Observation Space (I/O)
+  # -----------------------
+  obs space:
+    name: ompsnp_npp
+    distribution:
+      name: "{{distribution_type}}"
+      halo size: 1250e3
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdatain_path}}/{{atmosphere_obsdatain_prefix}}{{observation_from_jcb}}{{atmosphere_obsdatain_suffix}}"
+      obsgrouping:
+        group variables: ["latitude"]
+        sort variable: "pressure"
+        sort order: "ascending"
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"
+    io pool:
+      max pool size: 1
+    simulated variables: [ozoneLayer]
+
+  #obs operator:
+  #  name: AtmVertInterpLay
+  #  geovals: [mole_fraction_of_ozone_in_air]
+  #  coefficients: [0.007886131] # convert from ppmv to DU
+  #  nlevels: [22]
+
+  # Observation Operator
+  # --------------------
+  obs operator:
+    name: ColumnRetrieval
+    nlayers_retrieval: 1
+    tracer variables: [mole_fraction_of_ozone_in_air]
+    isApriori: false
+    isAveragingKernel: false
+    totalNoVertice: false
+    stretchVertices: none #options: top, bottom, topbottom, none
+  # model units coeff: 2.240013904035E-3 # this number to match the gsihofx values
+    model units coeff: 2.241398632746E-3 # this number to match the gsihofx values (use this)
+                                         # the actual scientific conversion factor is
+                                         # 2.1415E-3 kg[O3]/m-2 to DU
+                                         # so the name of the geovals
+                                         # is also likely wrong, as it apprears to be a mass
+                                         # fraction given the conversion factor needed
+
+  # Observation Pre Filters (QC)
+  # ----------------------------
+  obs pre filters:
+  # Observation error assignment
+  - filter: Perform Action
+    filter variables:
+    - name: ozoneLayer
+    action:
+      name: assign error
+      error function:
+        name: ObsFunction/ObsErrorModelStepwiseLinear
+        options:
+          xvar:
+            name: MetaData/pressure
+          xvals: [0.001, 10.1325, 16.00935, 25.43258, 40.32735, 63.93607, 101.325,
+            160.0935, 254.3257, 403.2735, 639.3608, 1013.25, 1600.935, 2543.258, 4032.735,
+            6393.607, 10132.5, 16009.35, 25432.57, 40327.35, 63936.07, 101325]
+  #       errors: [7.7236, 0.020, 0.020, 0.025, 0.080, 0.150, 0.056, 0.125, 0.200,
+  #         0.299, 0.587, 0.864, 1.547, 2.718, 3.893, 4.353, 3.971, 4.407, 4.428,
+  #         3.312, 2.198, 2.285]
+          errors: [7.7236, 0.020, 0.020, 0.025, 0.040, 0.080, 0.156, 0.245, 0.510,
+            1.098, 3.917, 6.124, 6.347, 5.798, 6.843, 9.253,10.091,10.967, 8.478,
+            5.572, 2.638, 3.525]  # operational from gfs.v16.3.9 (late 2023)
+
+  # Observation Prior Filters (QC)
+  # ------------------------------
+  obs prior filters:
+  # Do not assimilation where pressure is zero
+  # Zero pressure indicates the data is total column ozone
+  - filter: RejectList
+    filter variables:
+    - name: ozoneLayer
+    where:
+    - variable:
+        name: MetaData/pressure
+      maxvalue: 0.0001
+
+  # Sanity check on observaton values
+  - filter: Bounds Check
+    filter variables:
+    - name: ozoneLayer
+    minvalue: 0
+    maxvalue: 1000
+    action:
+      name: reject
+
+  # Total Ozone Quality Check (keeps 0, 2)
+  # 0 indentifies good data
+  # 2 identifies good data with a solar zenith angle > 84 degrees
+  - filter: RejectList
+    filter variables:
+    - name: ozoneLayer
+    where:
+    - variable:
+        name: MetaData/totalOzoneQuality
+      is_not_in: 0, 2
+
+  # Profile Ozone Quality Check (keeps 0, 1, 7)
+  # 0 : good data
+  # 1 : good data with a solar zenith angle > 84 degrees
+  # 7 : profile for which stray light correction applied
+  - filter: RejectList
+    filter variables:
+    - name: ozoneLayer
+    where:
+    - variable:
+        name: MetaData/profileOzoneQuality
+      is_not_in: 0, 1, 7
+
+  # Observation Post Filters (QC)
+  # -----------------------------
+  obs post filters:
+  # Gross error check
+  - filter: Background Check
+    filter variables:
+    - name: ozoneLayer
+    absolute threshold: 120
+    action:
+      name: reject
+    where:
+    - variable:
+        name: MetaData/pressure
+      maxvalue: 0.001
+
+  - filter: Background Check
+    filter variables:
+    - name: ozoneLayer
+    absolute threshold: 30
+    action:
+      name: reject
+    where:
+    - variable:
+        name: MetaData/pressure
+      minvalue: 30000.0
+      maxvalue: 110000.0
+
+  - filter: Background Check
+    filter variables:
+    - name: ozoneLayer
+    absolute threshold: 40
+    action:
+      name: reject
+    where:
+    - variable:
+        name: MetaData/pressure
+      minvalue: 20000.0
+      maxvalue: 30000.0
+
+  - filter: Background Check
+    filter variables:
+    - name: ozoneLayer
+    absolute threshold: 44.42
+    action:
+      name: reject
+    where:
+    - variable:
+        name: MetaData/pressure
+      minvalue: 10100.0
+      maxvalue: 20000.0
+
+  - filter: Background Check
+    filter variables:
+    - name: ozoneLayer
+    absolute threshold: 57.52
+    action:
+      name: reject
+    where:
+    - variable:
+        name: MetaData/pressure
+      minvalue: 6400.0
+      maxvalue: 10100.0
+
+  - filter: Background Check
+    filter variables:
+    - name: ozoneLayer
+    absolute threshold: 69.4
+    action:
+      name: reject
+    where:
+    - variable:
+        name: MetaData/pressure
+      minvalue: 4000.0
+      maxvalue: 6400.0
+
+  - filter: Background Check
+    filter variables:
+    - name: ozoneLayer
+    absolute threshold: 70
+    action:
+      name: reject
+    where:
+    - variable:
+        name: MetaData/pressure
+      minvalue: 2600.0
+      maxvalue: 4000.0
+
+  - filter: Background Check
+    filter variables:
+    - name: ozoneLayer
+    absolute threshold: 62.73
+    action:
+      name: reject
+    where:
+    - variable:
+        name: MetaData/pressure
+      minvalue: 1600.0
+      maxvalue: 2600.0
+
+  - filter: Background Check
+    filter variables:
+    - name: ozoneLayer
+    absolute threshold: 50.52
+    action:
+      name: reject
+    where:
+    - variable:
+        name: MetaData/pressure
+      minvalue: 1100.0
+      maxvalue: 1600.0
+
+  - filter: Background Check
+    filter variables:
+    - name: ozoneLayer
+    absolute threshold: 35.9
+    action:
+      name: reject
+    where:
+    - variable:
+        name: MetaData/pressure
+      minvalue: 700.0
+      maxvalue: 1100.0
+
+  - filter: Background Check
+    filter variables:
+    - name: ozoneLayer
+    absolute threshold: 26.41
+    action:
+      name: reject
+    where:
+    - variable:
+        name: MetaData/pressure
+      minvalue: 400.0
+      maxvalue: 700.0
+
+  - filter: Background Check
+    filter variables:
+    - name: ozoneLayer
+    absolute threshold: 20.51
+    action:
+      name: reject
+    where:
+    - variable:
+        name: MetaData/pressure
+      minvalue: 300.0
+      maxvalue: 400.0
+
+  - filter: Background Check
+    filter variables:
+    - name: ozoneLayer
+    absolute threshold: 12.82
+    action:
+      name: reject
+    where:
+    - variable:
+        name: MetaData/pressure
+      minvalue: 200.0
+      maxvalue: 300.0
+
+  - filter: Background Check
+    filter variables:
+    - name: ozoneLayer
+    absolute threshold: 10
+    action:
+      name: reject
+    where:
+    - variable:
+        name: MetaData/pressure
+      minvalue: 70.0
+      maxvalue: 200.0
+
+  - filter: Background Check
+    filter variables:
+    - name: ozoneLayer
+    absolute threshold: 5
+    action:
+      name: reject
+    where:
+    - variable:
+        name: MetaData/pressure
+      minvalue: 40.0
+      maxvalue: 70.0
+
+  - filter: Background Check
+    filter variables:
+    - name: ozoneLayer
+    absolute threshold: 2
+    action:
+      name: reject
+    where:
+    - variable:
+        name: MetaData/pressure
+      minvalue: 30.0
+      maxvalue: 40.0
+
+  - filter: Background Check
+    filter variables:
+    - name: ozoneLayer
+    absolute threshold: 1
+    action:
+      name: reject
+    where:
+    - variable:
+        name: MetaData/pressure
+      maxvalue: 30.0
+
+  # End of Filters
+
+  # Observation Localizations (LocalEnsembleDA)
+  # -------------------------------------------
+  obs localizations:
+  - localization method: Horizontal Gaspari-Cohn
+    lengthscale: 1250e3
+    max nobs: 10000
+    
+  # GeoVaLs for Driving Observation Operators (testing mode)
+  # --------------------------------------------------------
+  geovals:
+    filename: "{{atmosphere_obsdatain_path}}/{{atmosphere_obsdatain_prefix}}{{observation_from_jcb}}_geoval{{atmosphere_obsdatain_suffix}}"
+
+  # Passed benchmark for UFO testing
+  # --------------------------------
+  passedBenchmark: 0

--- a/observations/atmosphere-lgetkf/ozone.ompstc_npp.yaml.j2
+++ b/observations/atmosphere-lgetkf/ozone.ompstc_npp.yaml.j2
@@ -1,0 +1,142 @@
+-
+
+  # Observation Space (I/O)
+  # -----------------------
+  obs space:
+    name: ompstc_npp
+    distribution:
+      name: "{{distribution_type}}"
+      halo size: 1250e3    
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdatain_path}}/{{atmosphere_obsdatain_prefix}}{{observation_from_jcb}}{{atmosphere_obsdatain_suffix}}"
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"
+    io pool:
+      max pool size: 1
+    simulated variables: [ozoneTotal]
+
+  #obs operator:
+  #  name: AtmVertInterpLay
+  #  geovals: [mole_fraction_of_ozone_in_air]
+  #  coefficients: [0.007886131] # convert from ppmv to DU
+  #  nlevels: [1]
+
+  # Observation Operator
+  # --------------------
+  obs operator:
+    name: ColumnRetrieval
+    nlayers_retrieval: 1
+    tracer variables: [mole_fraction_of_ozone_in_air]
+    isApriori: false
+    isAveragingKernel: false
+    totalNoVertice: true
+    stretchVertices: topbottom # options: top, bottom, topbottom, none
+    model units coeff: 2.241398632746E-3
+
+  # Observation Pre Filters (QC)
+  # ----------------------------
+  obs pre filters:
+  # assign observation error
+  - filter: Perform Action
+    filter variables:
+    - name: ozoneTotal
+    action:
+      name: assign error
+      error parameter: 6.0
+
+  # GSI read routine QC
+  # range sanity check
+  - filter: Bounds Check
+    filter variables:
+    - name: ozoneTotal
+    minvalue: 0
+    maxvalue: 1000
+    action:
+      name: reject
+
+  #- filter: Gaussian Thinning
+  #  horizontal_mesh: 150
+  #  use_reduced_horizontal_grid: true
+  #  distance_norm: geodesic
+  #  action:
+  #    name: reject
+
+  # Accept total_ozone_error_flag values of 0 and 1, but not any others.
+  - filter: RejectList
+    filter variables:
+    - name: ozoneTotal
+    where:
+    - variable:
+        name: MetaData/totalOzoneQualityCode
+      is_not_in: 0, 1
+
+  - filter: RejectList
+    filter variables:
+    - name: ozoneTotal
+    where:
+    - variable:
+        name: MetaData/bestOzoneAlgorithmFlag
+      is_in: 3, 13
+
+  # GSI setup routine QC
+  - filter: RejectList
+    filter variables:
+    - name: ozoneTotal
+    where:
+    - variable:
+        name: MetaData/sensorScanPosition
+      is_in: 1, 2, 3, 4, 35
+    - variable:
+        name: MetaData/latitude
+      minvalue: 50.0
+
+  - filter: RejectList
+    filter variables:
+    - name: ozoneTotal
+    where:
+    - variable:
+        name: MetaData/sensorScanPosition
+      is_in: 1, 2, 3, 4, 35
+    - variable:
+        name: MetaData/latitude
+      maxvalue: -50.0
+
+  - filter: Gaussian Thinning
+    horizontal_mesh: 150
+    use_reduced_horizontal_grid: true
+    distance_norm: geodesic
+    action:
+      name: reduce obs space
+
+  # Observation Post Filters (QC)
+  # -----------------------------
+  obs post filters:
+  - filter: Background Check
+    filter variables:
+    - name: ozoneTotal
+    threshold: 10.0
+    absolute threshold: 300.0
+    action:
+      name: reject
+
+  # End of Filters
+
+  # Observation Localizations (LocalEnsembleDA)
+  # -------------------------------------------
+  obs localizations:
+  - localization method: Horizontal Gaspari-Cohn
+    lengthscale: 1250e3
+    max nobs: 10000
+
+  # GeoVaLs for Driving Observation Operators (testing mode)
+  # --------------------------------------------------------
+  geovals:
+    filename: "{{atmosphere_obsdatain_path}}/{{atmosphere_obsdatain_prefix}}{{observation_from_jcb}}_geoval{{atmosphere_obsdatain_suffix}}"
+
+  # Passed benchmark for UFO testing
+  # --------------------------------
+  passedBenchmark: 0

--- a/observations/atmosphere-lgetkf/scatwnd.ascat_metop-b.yaml.j2
+++ b/observations/atmosphere-lgetkf/scatwnd.ascat_metop-b.yaml.j2
@@ -1,0 +1,325 @@
+-
+
+  # Observation Space (I/O)
+  # -----------------------
+  obs space:
+    name: ascatw_ascat_metop-b
+    distribution:
+      name: "{{distribution_type}}"
+      halo size: 1250e3
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdatain_path}}/{{atmosphere_obsdatain_prefix}}{{observation_from_jcb}}{{atmosphere_obsdatain_suffix}}"
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"
+    io pool:
+      max pool size: 1
+    simulated variables: [windEastward, windNorthward]
+
+  # Observation Operator
+  # --------------------
+  obs operator:
+    name: VertInterp
+    # Use height vertical coordinate first
+  # vertical coordinate: geometric_height
+    vertical coordinate: geopotential_height
+    observation vertical coordinate group: DerivedVariables
+    observation vertical coordinate: adjustedHeight
+    interpolation method: linear
+    hofx scaling field: SurfaceWindScalingHeight
+    hofx scaling field group: DerivedVariables
+
+  # Linear Observation Operator
+  # ---------------------------
+  linear obs operator:
+    name: VertInterp
+    vertical coordinate: geopotential_height
+    observation vertical coordinate group: DerivedVariables
+    observation vertical coordinate: adjustedHeight
+    interpolation method: linear
+
+  # Observation Pre Filters (QC)
+  # ----------------------------
+  obs pre filters:
+  - filter: Gaussian Thinning
+    horizontal_mesh: 75
+    use_reduced_horizontal_grid: true
+    round_horizontal_bin_count_to_nearest: true
+    partition_longitude_bins_using_mesh: true
+    action:
+      name: reduce obs space
+
+  # Observation Prior Filters (QC)
+  # ------------------------------
+  obs prior filters:
+  # Apply variable changes needed for rescaled height coordinate
+  - filter: Variable Transforms
+    Transform: AdjustedHeightCoordinate
+    SkipWhenNoObs: false
+
+  # Apply variable changes needed for wind scaling
+  - filter: Variable Transforms
+    Transform: SurfaceWindScalingHeight
+    SkipWhenNoObs: false
+
+  # Assign the initial observation error (constant value, 1.5 m/s right now).
+  - filter: Perform Action
+    filter variables:
+    - name: windEastward
+    - name: windNorthward
+    action:
+      name: assign error
+      error parameter: 1.5
+
+  # Calculate error inflation factor for duplicate observations
+  #- filter: Variable Assignment
+  #  assignments:
+  #  - name: ObsErrorFactorDuplicateCheck/windEastward
+  #    type: float
+  #    function:
+  #      name: ObsFunction/ObsErrorFactorDuplicateCheck
+  #      options:
+  #        use_air_pressure: true
+  #        variable: windEastward
+  #- filter: Variable Assignment
+  #  assignments:
+  #  - name: ObsErrorFactorDuplicateCheck/windNorthward
+  #    type: float
+  #    function:
+  #      name: ObsFunction/ObsErrorFactorDuplicateCheck
+  #      options:
+  #        use_air_pressure: true
+  #        variable: windNorthward
+  # Reject all obs with PreQC mark already set above 3
+  # NOTE: All scatwinds have an automatic PreQC mark of 2 (hard-wired default from GSI)
+  # - filter: PreQC
+  #   maxvalue: 3
+  #   action:
+  #     name: reject
+
+  # Observation Post Filters (QC)
+  # -----------------------------
+  obs post filters:
+  # Reject all ASCAT (Type 290) winds with tsavg <= 273.0 (surface temperature)
+  - filter: Perform Action
+    filter variables:
+    - name: windEastward
+    - name: windNorthward
+    where:
+    - variable: ObsType/windEastward
+      is_in: 290
+  #   - variable: GeoVaLs/surface_temperature
+    - variable: GeoVaLs/skin_temperature_at_surface_where_land
+      maxvalue: 273.
+    action:
+      name: reject
+
+  # Reject all ASCAT (Type 290) winds with isflg /= 0 (non-water surface)
+  - filter: Perform Action
+    filter variables:
+    - name: windEastward
+    - name: windNorthward
+    where:
+    - variable: ObsType/windEastward
+      is_in: 290
+    - variable: GeoVaLs/water_area_fraction
+      maxvalue: 0.99
+    action:
+      name: reject
+
+  # Reject ASCAT (Type 290) when observed component deviates from background by more than 5.0 m/s
+  # NOTE: This check can reject a u- or v-component of the same observation independently, which
+  #       is fundamentally different from how GSI rejects obs (both components are rejected if
+  #       either component fails a check).
+  - filter: Bounds Check
+    filter variables:
+    - name: windEastward
+    - name: windNorthward
+    test variables:
+    - name: ObsFunction/Arithmetic
+      options:
+        variables:
+        - name: ObsValue/windEastward
+        - name: HofX/windEastward
+        coefs: [1.0, -1.0]
+    minvalue: -5.0
+    maxvalue: 5.0
+
+  - filter: Bounds Check
+    filter variables:
+    - name: windEastward
+    - name: windNorthward
+    test variables:
+    - name: ObsFunction/Arithmetic
+      options:
+        variables:
+        - name: ObsValue/windNorthward
+        - name: HofX/windNorthward
+        coefs: [1.0, -1.0]
+    minvalue: -5.0
+    maxvalue: 5.0
+
+  # Reject OSCAT (Type 291) when observed component deviates from background by more than 6.0 m/s
+  # NOTE: This check can reject a u- or v-component of the same observation independently, which
+  #       is fundamentally different from how GSI rejects obs (both components are rejected if
+  #       either component fails a check).
+  - filter: Background Check
+    filter variables:
+    - name: windEastward
+    - name: windNorthward
+    threshold: 6.
+    absolute threshold: 6.
+    where:
+    - variable: ObsType/windEastward
+      is_in: 291
+    action:
+      name: reject
+
+  # Reject ASCAT (Type 290) when ambiguity check fails (returned value is negative)
+  - filter: Bounds Check
+    filter variables:
+    - name: windEastward
+    - name: windNorthward
+    where:
+    - variable: ObsType/windEastward
+      is_in: 290
+    test variables:
+    - name: ObsFunction/ScatWindsAmbiguityCheck
+      options:
+        minimum_uv: 0.0001 # hard-coding a minimum-uv for transparancy, want this to basically be zero
+    maxvalue: 0.
+    action:
+      name: reject
+
+  # All scatwinds must adjust errors based on ObsErrorFactorPressureCheck.
+  # This check will inflate errors for obs that are too close to either
+  # the model top or bottom.
+  - filter: Perform Action
+    filter variables:
+    - name: windEastward
+    where:
+    - variable:
+        name: ObsType/windEastward
+      is_in: 290-291
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorPressureCheck
+        options:
+          variable: windEastward
+          inflation factor: 4.0
+
+  - filter: Perform Action
+    filter variables:
+    - name: windNorthward
+    where:
+    - variable:
+        name: ObsType/windNorthward
+      is_in: 290-291
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorPressureCheck
+        options:
+          variable: windNorthward
+          inflation factor: 4.0
+
+  # All scatwinds subject to a gross error check. This is contained within
+  # the WindsSPDBCheck, although it is not exclusive to satwinds.
+  - filter: Background Check
+    filter variables:
+    - name: windEastward
+    function absolute threshold:
+    - name: ObsFunction/WindsSPDBCheck
+      options:
+        wndtype: [290, 291]
+        cgross: [5.0, 5.0]
+        error_min: [1.4, 1.4]
+        error_max: [6.1, 6.1]
+        variable: windEastward
+    action:
+      name: reject
+
+  - filter: Background Check
+    filter variables:
+    - name: windNorthward
+    function absolute threshold:
+    - name: ObsFunction/WindsSPDBCheck
+      options:
+        wndtype: [290, 291]
+        cgross: [5.0, 5.0]
+        error_min: [1.4, 1.4]
+        error_max: [6.1, 6.1]
+        variable: windNorthward
+    action:
+      name: reject
+
+  # The last error inflation check is for duplicate observations. This one needs
+  # to come last, because we don"t want to inflate errors for duplication if one
+  # of the duplicates should be rejected.
+  #- filter: Perform Action
+  #  filter variables:
+  #  - name: windEastward
+  #  action:
+  #    name: inflate error
+  #    inflation variable:
+  #      name: ObsErrorFactorDuplicateCheck/windEastward
+  #- filter: Perform Action
+  #  filter variables:
+  #  - name: windNorthward
+  #  action:
+  #    name: inflate error
+  #    inflation variable:
+  #      name: ObsErrorFactorDuplicateCheck/windNorthward
+  # There is no across-the-board inflation for nvqc=.true. for scatwinds, presumably because for
+  # this inflation to take place both nvqc must be .true. AND ibeta must be >0, see:
+  # https://github.com/NOAA-EMC/GSI/blob/14ae595af1b03471287d322596d35c0665336e95/src/gsi/setupw.f90#L1229
+  # GSI settings must have ibeta>0 for satwinds, but not for scatwinds.
+  # 
+  # If the ibeta settings for scatwinds were to change while nvqc remained .true., we would extend YAML to
+  # an additional filter that inflates final ob-errors across-the-board by 1/0.8 = 1.25. NOTE: the nvqc setting
+  # is defaulted to .false. in GSI code, but is overridden in global operational configuration. See:
+  # configuration, see: https://github.com/NOAA-EMC/global-workflow/blob/d5ae3328fa4041b177357b1133f6b92e81c859d7/scripts/exglobal_atmos_analysis.sh#L750
+  # This setting activates Line 1229 of setupw.f90 to scale ratio_errors by 0.8, which is applied in
+  # the denominator of the final ob-error, so 1/0.8 = 1.25 factor of ob-error inflation.
+  #
+  # If this functionality were to be activated for scatwinds, you would want to include this last inflation filter.
+  #- filter: Perform Action
+  #  filter variables:
+  #  - name: windEastward
+  #  where:
+  #  - variable: ObsType/windEastward
+  #    is_in: 290-291
+  #  action:
+  #    name: inflate error
+  #    inflation factor: 1.25
+  #- filter: Perform Action
+  #  filter variables:
+  #  - name: windNorthward
+  #  where:
+  #  - variable: ObsType/windNorthward
+  #    is_in: 290-291
+  #  action:
+  #    name: inflate error
+  #    inflation factor: 1.25
+  # END OF FILTERS#
+
+
+  # Observation Localizations (LocalEnsembleDA)
+  # -------------------------------------------
+  obs localizations:
+  - localization method: Horizontal Gaspari-Cohn
+    lengthscale: 1250e3
+    max nobs: 10000
+
+  # GeoVaLs for Driving Observation Operators (testing mode)
+  # --------------------------------------------------------
+  geovals:
+    filename: "{{atmosphere_obsdatain_path}}/{{atmosphere_obsdatain_prefix}}{{observation_from_jcb}}_geoval{{atmosphere_obsdatain_suffix}}"
+
+  # Passed benchmark for UFO testing
+  # --------------------------------
+  passedBenchmark: 0


### PR DESCRIPTION
This PR adds the following yamls to `observations/atmosphere-lgetkf`
- `gnssro_cosmic2.yaml.j2`
- `ozone.ompsnp_npp.yaml.j2`
- `ozone.ompstc_npp.yaml.j2`
- `scatwnd.ascat_metop-b.yaml.j2`

Addition of these yamls to `observations/atmospher-lgetkf` allows the local ensemble DA jobs in `test_gdasapp_C96C48_ufs_hybatmDA` to return to the previous level of functionality.

Resolves #173