### PR TITLE
Revert unnecessary copilot changes

### DIFF
--- a/model/atmosphere/atmosphere_3dvar_outer_loop_1.yaml.j2
+++ b/model/atmosphere/atmosphere_3dvar_outer_loop_1.yaml.j2
@@ -1,4 +1,4 @@
-- ninner: {{atmosphere_ninner_1}}
+- ninner: 2
   gradient norm reduction: 1e-10
   test: on
   geometry:

--- a/model/atmosphere/atmosphere_3dvar_outer_loop_2.yaml.j2
+++ b/model/atmosphere/atmosphere_3dvar_outer_loop_2.yaml.j2
@@ -1,4 +1,4 @@
-- ninner: {{atmosphere_ninner_2}}
+- ninner: 4
   gradient norm reduction: 1e-10
   test: on
   geometry:

--- a/test/client_integration/gdas-atmosphere-templates.yaml
+++ b/test/client_integration/gdas-atmosphere-templates.yaml
@@ -69,25 +69,18 @@ atmosphere_ensemble_analysis_prefix: "anl_"
 atmosphere_background_time_iso: '2024-02-02T00:00:00Z'
 
 # Background error
-
 atmosphere_bump_data_directory: DATA/berror
 atmosphere_gsibec_path: DATA/berror
 atmosphere_number_ensemble_members: 3
 atmosphere_layout_gsib_x: 2
 atmosphere_layout_gsib_y: 2
 
-
 # Forecasting
 atmosphere_forecast_length: PT6H
 atmosphere_forecast_timestep: PT1H
 
-# Minimization
-atmosphere_ninner_1: 2
-atmosphere_ninner_2: 4
-
 # Write final increment on Gaussian grid in variational
 atmosphere_final_increment_prefix: "./anl/atminc."
-
 
 # Observation things
 # ------------------


### PR DESCRIPTION
This PR reverts some of that changes made in https://github.com/NOAA-EMC/jcb-gdas/pull/170 . These were changes were from copilot's initial changes meant to fix CI testing via GitHub Actions. A later round of changes fixed the CI, but the other changes remain.

Without this PR, certain atmospheric JEDI yamls will fail to render with JCB due to the absence of parameters in jcb-base.yaml.j2