### PR TITLE
Skip copy if aero obs file is missing

### DIFF
--- a/algorithm/aero/aero_obs_staging.yaml.j2
+++ b/algorithm/aero/aero_obs_staging.yaml.j2
@@ -1,6 +1,6 @@
 mkdir:
     - '{{aero_obsdatain_path}}'
-copy:
+copy_opt:
     {% for observation_from_jcb in observations %}
     {% if use_observer(observation_from_jcb) %}
     - ['{{aero_obsdataroot_path}}/{{aero_obsdatain_prefix}}{{observation_from_jcb}}{{aero_obsdatain_suffix}}', '{{aero_obsdatain_path}}']


### PR DESCRIPTION
This PR updates the yaml to skip copying when a source aerosol observation file is missing.