### PR TITLE
Addition of the "missing file action" yaml key to the marine obs yamls

### DIFF
--- a/observations/marine/adt_rads_all.yaml.j2
+++ b/observations/marine/adt_rads_all.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File

--- a/observations/marine/icec_amsr2_north.yaml.j2
+++ b/observations/marine/icec_amsr2_north.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File

--- a/observations/marine/icec_amsr2_south.yaml.j2
+++ b/observations/marine/icec_amsr2_south.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File

--- a/observations/marine/icec_generic_passive.yaml.j2
+++ b/observations/marine/icec_generic_passive.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File

--- a/observations/marine/icec_ssmis_f17_l2.yaml.j2
+++ b/observations/marine/icec_ssmis_f17_l2.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File

--- a/observations/marine/insitu_profile_bathy.yaml.j2
+++ b/observations/marine/insitu_profile_bathy.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File

--- a/observations/marine/insitu_profile_glider.yaml.j2
+++ b/observations/marine/insitu_profile_glider.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File

--- a/observations/marine/insitu_profile_marinemammal.yaml.j2
+++ b/observations/marine/insitu_profile_marinemammal.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File

--- a/observations/marine/insitu_profile_tesac.yaml.j2
+++ b/observations/marine/insitu_profile_tesac.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File

--- a/observations/marine/insitu_profile_tesac_salinity.yaml.j2
+++ b/observations/marine/insitu_profile_tesac_salinity.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File

--- a/observations/marine/insitu_profile_tropical.yaml.j2
+++ b/observations/marine/insitu_profile_tropical.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File

--- a/observations/marine/insitu_profile_xbtctd.yaml.j2
+++ b/observations/marine/insitu_profile_xbtctd.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File

--- a/observations/marine/insitu_salt_profile_argo.yaml.j2
+++ b/observations/marine/insitu_salt_profile_argo.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
       obsgrouping:
         group variables: [latitude, longitude, dateTime]
         sort variable: depth

--- a/observations/marine/insitu_surface_altkob.yaml.j2
+++ b/observations/marine/insitu_surface_altkob.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File

--- a/observations/marine/insitu_surface_dbuoyb_drifter.yaml.j2
+++ b/observations/marine/insitu_surface_dbuoyb_drifter.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File
@@ -53,4 +54,3 @@
     min value: 200.0e3
     max value: 900.0e3
 {% endif %}
-

--- a/observations/marine/insitu_surface_trkob.yaml.j2
+++ b/observations/marine/insitu_surface_trkob.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File

--- a/observations/marine/insitu_surface_trkob_salinity.yaml.j2
+++ b/observations/marine/insitu_surface_trkob_salinity.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File

--- a/observations/marine/insitu_temp_profile_argo.yaml.j2
+++ b/observations/marine/insitu_temp_profile_argo.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
       obsgrouping:
         group variables: [latitude, longitude, dateTime]
         sort variable: depth

--- a/observations/marine/insitu_temp_surface_drifter.yaml.j2
+++ b/observations/marine/insitu_temp_surface_drifter.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File
@@ -57,4 +58,3 @@
     min value: 200.0e3
     max value: 900.0e3
 {% endif %}
-

--- a/observations/marine/sss_smap_l2.yaml.j2
+++ b/observations/marine/sss_smap_l2.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File

--- a/observations/marine/sss_smos_l2.yaml.j2
+++ b/observations/marine/sss_smos_l2.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File

--- a/observations/marine/sst_generic.yaml.j2
+++ b/observations/marine/sst_generic.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File

--- a/observations/marine/sst_generic_geo.yaml.j2
+++ b/observations/marine/sst_generic_geo.yaml.j2
@@ -4,6 +4,7 @@
       engine:
         type: H5File
         obsfile: "{{marine_obsdatain_path}}/{{marine_obsdatain_prefix}}{{observation_from_jcb}}{{marine_obsdatain_suffix}}"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File


### PR DESCRIPTION
Thanks to @CoryMartin-NOAA for pointing us to a simple fix:
- fixes #183 