### PR TITLE
Do FOV average for atms_n20 observations.

### DIFF
--- a/observations/atmosphere/atms_n20.yaml.j2
+++ b/observations/atmosphere/atms_n20.yaml.j2
@@ -32,6 +32,8 @@
       Sensor_ID: &{{observation_from_jcb}}_sensor_id atms_n20
       EndianType: little_endian
       CoefficientPath: "{{crtm_coefficient_path}}"
+    do fov average: true
+    fov sample points per semimajor axis: 4
     linear obs operator:
       Absorbers: [H2O, O3]
 


### PR DESCRIPTION
Conduct averages of GeoVals within the field of view (FOV) of AMTS_N20 observations as what is conducted in GSI.