### PR TITLE
Modify the maximum value of station elevation to 3000 m

### DIFF
--- a/observations/snow/adpsfc_snow.yaml.j2
+++ b/observations/snow/adpsfc_snow.yaml.j2
@@ -114,7 +114,7 @@
       - variable:
           name: MetaData/stationElevation
         minvalue: -200.0
-        maxvalue: 9900.0
+        maxvalue: 3000.0
       actions:
       - name: set
         flag: invalid_elevation

--- a/observations/snow/ghcn_snow.yaml.j2
+++ b/observations/snow/ghcn_snow.yaml.j2
@@ -99,7 +99,7 @@
       - variable:
           name: MetaData/stationElevation
         minvalue: -200.0
-        maxvalue: 9900.0
+        maxvalue: 3000.0
       actions:
       - name: set
         flag: invalid_elevation

--- a/observations/snow/ims_snow.yaml.j2
+++ b/observations/snow/ims_snow.yaml.j2
@@ -35,6 +35,8 @@
       initial value: false
     - name: invalid_snowdepth
       initial value: false
+    - name: invalid_elevation
+      initial value: false
     - name: background_check
       initial value: false
     - name: spatial_thinning
@@ -57,6 +59,17 @@
     actions:
     - name: set
       flag: land_check
+      ignore: rejected observations
+    - name: reject
+  - filter: Domain Check
+    where:
+    - variable:
+        name: MetaData/stationElevation
+      minvalue: -200.0
+      maxvalue: 3000.0
+    actions:
+    - name: set
+      flag: invalid_elevation
       ignore: rejected observations
     - name: reject
   - filter: Domain Check # land only, no sea ice

--- a/observations/snow/madis_snow.yaml.j2
+++ b/observations/snow/madis_snow.yaml.j2
@@ -113,7 +113,7 @@
       - variable:
           name: MetaData/stationElevation
         minvalue: -200.0
-        maxvalue: 9900.0
+        maxvalue: 3000.0
       actions:
       - name: set
         flag: invalid_elevation

--- a/observations/snow/sfcsno.yaml.j2
+++ b/observations/snow/sfcsno.yaml.j2
@@ -114,7 +114,7 @@
       - variable:
           name: MetaData/stationElevation
         minvalue: -200.0
-        maxvalue: 9900.0
+        maxvalue: 3000.0
       actions:
       - name: set
         flag: invalid_elevation

--- a/observations/snow/snocvr.yaml.j2
+++ b/observations/snow/snocvr.yaml.j2
@@ -114,7 +114,7 @@
       - variable:
           name: MetaData/stationElevation
         minvalue: -200.0
-        maxvalue: 9900.0
+        maxvalue: 3000.0
       actions:
       - name: set
         flag: invalid_elevation

--- a/observations/snow/snocvr_snomad.yaml.j2
+++ b/observations/snow/snocvr_snomad.yaml.j2
@@ -113,7 +113,7 @@
       - variable:
           name: MetaData/stationElevation
         minvalue: -200.0
-        maxvalue: 9900.0
+        maxvalue: 3000.0
       actions:
       - name: set
         flag: invalid_elevation

--- a/observations/snow/snomad.yaml.j2
+++ b/observations/snow/snomad.yaml.j2
@@ -114,7 +114,7 @@
       - variable:
           name: MetaData/stationElevation
         minvalue: -200.0
-        maxvalue: 9900.0
+        maxvalue: 3000.0
       actions:
       - name: set
         flag: invalid_elevation


### PR DESCRIPTION
This PR implements the exclusion of observations with elevations above 3000 meters in the 2DVar snow DA.