### PR TITLE
Bring back thinning for ice obs with LETKF

### DIFF
--- a/observations/marine/icec_amsr2_north.yaml.j2
+++ b/observations/marine/icec_amsr2_north.yaml.j2
@@ -46,14 +46,14 @@
     action:
       name: inflate error
       inflation factor: 2.0
-#{% if marine_letkf_app | default(false) %}
-#  - filter: Gaussian Thinning
-#    horizontal_mesh: 25  #km
-#    use_reduced_horizontal_grid: true
-#    select_median: true
-#    action:
-#      name: reduce obs space
-#{% endif %}
+{% if marine_letkf_app | default(false) %}
+  - filter: Gaussian Thinning
+    horizontal_mesh: 25  #km
+    use_reduced_horizontal_grid: true
+    select_median: true
+    action:
+      name: reduce obs space
+{% endif %}
 {% if marine_letkf_app | default(false) %}
   obs localizations:
   - localization method: Rossby

--- a/observations/marine/icec_amsr2_south.yaml.j2
+++ b/observations/marine/icec_amsr2_south.yaml.j2
@@ -46,14 +46,14 @@
     action:
       name: inflate error
       inflation factor: 2.0
-#{% if marine_letkf_app | default(false) %}
-#  - filter: Gaussian Thinning
-#    horizontal_mesh: 25  #km
-#    use_reduced_horizontal_grid: true
-#    select_median: true
-#    action:
-#      name: reduce obs space
-#{% endif %}
+{% if marine_letkf_app | default(false) %}
+  - filter: Gaussian Thinning
+    horizontal_mesh: 25  #km
+    use_reduced_horizontal_grid: true
+    select_median: true
+    action:
+      name: reduce obs space
+{% endif %}
 {% if marine_letkf_app | default(false) %}
   obs localizations:
   - localization method: Rossby


### PR DESCRIPTION
Brings back thinning for ice obs with LETKF.
This option requires `use linear observer: true` in the LETKF, because the observations are thinned with option `reduce obs space`. When obs space is reduced, it's important to only do it once. `use linear observer: true` ensures that the QC filters are only run once, on the ensemble mean. When `use linear observer` is set to `false` (by default), QC filters are run on each ensemble member, which results in removing observations from the obs space multiple times and subsequent segfaults in the LETKF when the various vector sizes don't match.

Goes with https://github.com/NOAA-EMC/jcb-algorithms/pull/16 and a GDASApp PR.