### PR TITLE
Update snow filenames to comply with EE2 standards

### DIFF
--- a/algorithm/obstats/snow/ims_snow_template.yaml.j2
+++ b/algorithm/obstats/snow/ims_snow_template.yaml.j2
@@ -10,10 +10,10 @@
   variables: [totalSnowDepth]
   groups to process: ['ombg', 'oman']
   qc groups: ['EffectiveQC0', 'EffectiveQC1']
-  output file: "{{ obspace }}_{{ stat_current_cycle_YMDH }}_output_snow.nc"
+  output file: "{{ stat_current_cycle_YMDH }}.ioda_hofx_stats.{{ obspace }}.nc"
   regular grid binning:
     bin size in degrees: 2.0
-    use negative longitudes: false 
+    use negative longitudes: false
   domains to process:
   - domain:
       name: "SH"

--- a/algorithm/obstats/snow/madis_snow_template.yaml.j2
+++ b/algorithm/obstats/snow/madis_snow_template.yaml.j2
@@ -1,5 +1,5 @@
 - obs space:
-    name: madis_snow 
+    name: madis_snow
     obsdatain:
       engine:
         type: H5File
@@ -10,10 +10,10 @@
   variables: [totalSnowDepth]
   groups to process: ['ombg', 'oman']
   qc groups: ['EffectiveQC0', 'EffectiveQC1']
-  output file: "{{ obspace }}_{{ stat_current_cycle_YMDH }}_output_snow.nc"
+  output file: "{{ stat_current_cycle_YMDH }}.ioda_hofx_stats.{{ obspace }}.nc"
   regular grid binning:
     bin size in degrees: 1.0
-    use negative longitudes: true 
+    use negative longitudes: true
   domains to process:
   - domain:
       name: "SH"

--- a/algorithm/obstats/snow/sfcsno_template.yaml.j2
+++ b/algorithm/obstats/snow/sfcsno_template.yaml.j2
@@ -10,10 +10,10 @@
   variables: [totalSnowDepth]
   groups to process: ['ombg', 'oman']
   qc groups: ['EffectiveQC0', 'EffectiveQC1']
-  output file: "{{ obspace }}_{{ stat_current_cycle_YMDH }}_output_snow.nc"
+  output file: "{{ stat_current_cycle_YMDH }}.ioda_hofx_stats.{{ obspace }}.nc"
   regular grid binning:
     bin size in degrees: 1.0
-    use negative longitudes: true 
+    use negative longitudes: true
   domains to process:
   - domain:
       name: "SH"

--- a/algorithm/obstats/snow/snocvr_template.yaml.j2
+++ b/algorithm/obstats/snow/snocvr_template.yaml.j2
@@ -10,10 +10,10 @@
   variables: [totalSnowDepth]
   groups to process: ['ombg', 'oman']
   qc groups: ['EffectiveQC0', 'EffectiveQC1']
-  output file: "{{ obspace }}_{{ stat_current_cycle_YMDH }}_output_snow.nc"
+  output file: "{{ stat_current_cycle_YMDH }}.ioda_hofx_stats.{{ obspace }}.nc"
   regular grid binning:
     bin size in degrees: 1.0
-    use negative longitudes: true 
+    use negative longitudes: true
   domains to process:
   - domain:
       name: "SH"


### PR DESCRIPTION
This updates the output filenames for the observation statistics files to comply with EE2 standards.  Prerequisite for https://github.com/NOAA-EMC/global-workflow/pull/4195.  Currently in testing.