### PR TITLE
Put quotes around datetimes

### DIFF
--- a/algorithm/aero/aero_addincrement.yaml.j2
+++ b/algorithm/aero/aero_addincrement.yaml.j2
@@ -23,7 +23,7 @@ increment geometry:
   npz: {{ aero_npz_ges }}
   field metadata override: ./fv3jedi/fv3jedi_fieldmetadata_restart.yaml
 state:
-  datetime: {{ aero_background_time_iso }}
+  datetime: '{{ aero_background_time_iso }}'
   state variables: {{ analysis_variables }}
   filetype: cube sphere history
   provider: ufs

--- a/algorithm/atmosphere/atm_addincrement.yaml.j2
+++ b/algorithm/atmosphere/atm_addincrement.yaml.j2
@@ -23,7 +23,7 @@ increment geometry:
   npz: {{ atmosphere_npz_ges }}
   field metadata override: ./fv3jedi/fv3jedi_fieldmetadata_fv3inc.yaml
 state:
-  datetime: {{ atmosphere_background_time_iso }}
+  datetime: '{{ atmosphere_background_time_iso }}'
   state variables:
   - eastward_wind
   - northward_wind

--- a/algorithm/atmosphere/fv3jedi_correction_increment.yaml.j2
+++ b/algorithm/atmosphere/fv3jedi_correction_increment.yaml.j2
@@ -54,7 +54,7 @@ correction increment geometry:
   npz: {{ atmosphere_npz_anl }}
 forecast hours:
 {% for ihour in range( atmosphere_iau_hours | length ) %}
-- datetime: {{ atmosphere_iau_times_iso[ihour] }}
+- datetime: '{{ atmosphere_iau_times_iso[ihour] }}'
   deterministic background:
     filetype: cube sphere history
     provider: ufs

--- a/algorithm/atmosphere/fv3jedi_ensemble_recenter.yaml.j2
+++ b/algorithm/atmosphere/fv3jedi_ensemble_recenter.yaml.j2
@@ -24,7 +24,7 @@ members:
     npy: {{ atmosphere_npy_anl }}
     npz: {{ atmosphere_npz_anl }}
   state:
-    datetime: {{ atmosphere_iau_times_iso[ihour] }}
+    datetime: '{{ atmosphere_iau_times_iso[ihour] }}'
     state variables:
     - eastward_wind
     - northward_wind

--- a/algorithm/snow/snow_addincrement.yaml.j2
+++ b/algorithm/snow/snow_addincrement.yaml.j2
@@ -23,7 +23,7 @@ increment geometry:
   npz: {{ snow_npz_ges }}
   field metadata override: ./fv3jedi/fv3jedi_fieldmetadata_restart.yaml
 state:
-  datetime: {{ snow_background_time_iso }}
+  datetime: '{{ snow_background_time_iso }}'
   state variables: {{ analysis_variables }}
   filetype: cube sphere history
   provider: ufs


### PR DESCRIPTION
This PR puts quotes around dates that are not already quoted. This prevents a rare bug that can cause the date formatting of a JCB date string variable to change.