### PR TITLE
Corrects sea salt bin mapping between forward operator and model

### DIFF
--- a/algorithm/aero/aero_convert_background.yaml.j2
+++ b/algorithm/aero/aero_convert_background.yaml.j2
@@ -39,6 +39,7 @@ states:
     - mass_fraction_of_sea_salt002_in_air
     - mass_fraction_of_sea_salt003_in_air
     - mass_fraction_of_sea_salt004_in_air
+    - mass_fraction_of_sea_salt005_in_air
     field io names:
       mass_fraction_of_dust001_in_air: dust1
       mass_fraction_of_dust002_in_air: dust2

--- a/algorithm/aero/aero_gen_bmatrix_diagb.yaml.j2
+++ b/algorithm/aero/aero_gen_bmatrix_diagb.yaml.j2
@@ -40,6 +40,7 @@ background:
   - mass_fraction_of_sea_salt002_in_air
   - mass_fraction_of_sea_salt003_in_air
   - mass_fraction_of_sea_salt004_in_air
+  - mass_fraction_of_sea_salt005_in_air
   field io names:
     mass_fraction_of_dust001_in_air: dust1
     mass_fraction_of_dust002_in_air: dust2
@@ -134,6 +135,7 @@ variables:
   - mass_fraction_of_sea_salt002_in_air
   - mass_fraction_of_sea_salt003_in_air
   - mass_fraction_of_sea_salt004_in_air
+  - mass_fraction_of_sea_salt005_in_air
 
 {% set rescaling_factor_file = aero_rescaling_factor_file|default(aero_gen_bmatrix_rescale_default) %}
 {% include rescaling_factor_file %}

--- a/algorithm/aero/aero_gen_bmatrix_diffusion.yaml.j2
+++ b/algorithm/aero/aero_gen_bmatrix_diffusion.yaml.j2
@@ -28,6 +28,7 @@ background:
   - mass_fraction_of_sea_salt002_in_air
   - mass_fraction_of_sea_salt003_in_air
   - mass_fraction_of_sea_salt004_in_air
+  - mass_fraction_of_sea_salt005_in_air
   field io names:
     mass_fraction_of_dust001_in_air: dust1
     mass_fraction_of_dust002_in_air: dust2

--- a/algorithm/aero/aero_gen_bmatrix_rescale_default.yaml.j2
+++ b/algorithm/aero/aero_gen_bmatrix_rescale_default.yaml.j2
@@ -25,7 +25,7 @@ rescaling factors:
   mass_fraction_of_sea_salt004_in_air:
     ocean rescaling factor: 1.0
     land rescaling factor: 1.0
-  mass_fraction_of_sea_salt004_in_air:
+  mass_fraction_of_sea_salt005_in_air:
     ocean rescaling factor: 1.0
     land rescaling factor: 1.0
   mass_fraction_of_dust001_in_air:

--- a/algorithm/aero/aero_gen_bmatrix_rescale_default.yaml.j2
+++ b/algorithm/aero/aero_gen_bmatrix_rescale_default.yaml.j2
@@ -1,6 +1,6 @@
 rescaling factors:
   mass_fraction_of_sulfate_in_air:
-    rescaling factor: 1.0
+    rescaling factor: 0.1
   mass_fraction_of_hydrophobic_black_carbon_in_air:
     ocean rescaling factor: 1.0
     land rescaling factor: 1.0
@@ -20,6 +20,9 @@ rescaling factors:
     ocean rescaling factor: 1.0
     land rescaling factor: 1.0
   mass_fraction_of_sea_salt003_in_air:
+    ocean rescaling factor: 1.0
+    land rescaling factor: 1.0
+  mass_fraction_of_sea_salt004_in_air:
     ocean rescaling factor: 1.0
     land rescaling factor: 1.0
   mass_fraction_of_sea_salt004_in_air:

--- a/model/aero/aero_background.yaml.j2
+++ b/model/aero/aero_background.yaml.j2
@@ -23,7 +23,6 @@ state variables:
 - mass_fraction_of_sea_salt002_in_air
 - mass_fraction_of_sea_salt003_in_air
 - mass_fraction_of_sea_salt004_in_air
-- mass_fraction_of_sea_salt005_in_air
 field io names:
   air_temperature: T
   air_pressure_thickness: delp
@@ -38,8 +37,7 @@ field io names:
   mass_fraction_of_dust003_in_air: dust3
   mass_fraction_of_dust004_in_air: dust4
   mass_fraction_of_dust005_in_air: dust5
-  mass_fraction_of_sea_salt001_in_air: seas1
-  mass_fraction_of_sea_salt002_in_air: seas2
-  mass_fraction_of_sea_salt003_in_air: seas3
-  mass_fraction_of_sea_salt004_in_air: seas4
-  mass_fraction_of_sea_salt005_in_air: seas5
+  mass_fraction_of_sea_salt001_in_air: seas2
+  mass_fraction_of_sea_salt002_in_air: seas3
+  mass_fraction_of_sea_salt003_in_air: seas4
+  mass_fraction_of_sea_salt004_in_air: seas5

--- a/model/aero/aero_background_error_static_diffusion.yaml.j2
+++ b/model/aero/aero_background_error_static_diffusion.yaml.j2
@@ -42,11 +42,10 @@ saber outer blocks:
         mass_fraction_of_dust003_in_air: dust3
         mass_fraction_of_dust004_in_air: dust4
         mass_fraction_of_dust005_in_air: dust5
-        mass_fraction_of_sea_salt001_in_air: seas1
-        mass_fraction_of_sea_salt002_in_air: seas2
-        mass_fraction_of_sea_salt003_in_air: seas3
-        mass_fraction_of_sea_salt004_in_air: seas4
-        mass_fraction_of_sea_salt005_in_air: seas5
+        mass_fraction_of_sea_salt001_in_air: seas2
+        mass_fraction_of_sea_salt002_in_air: seas3
+        mass_fraction_of_sea_salt003_in_air: seas4
+        mass_fraction_of_sea_salt004_in_air: seas5
         mass_fraction_of_hydrophobic_black_carbon_in_air: bc1
         mass_fraction_of_hydrophilic_black_carbon_in_air: bc2
         mass_fraction_of_hydrophobic_organic_carbon_in_air: oc1

--- a/model/aero/aero_final_increment_cubed_sphere.yaml.j2
+++ b/model/aero/aero_final_increment_cubed_sphere.yaml.j2
@@ -44,10 +44,10 @@ output:
       mass_fraction_of_dust003_in_air: dust3
       mass_fraction_of_dust004_in_air: dust4
       mass_fraction_of_dust005_in_air: dust5
-      mass_fraction_of_sea_salt001_in_air: seas1
-      mass_fraction_of_sea_salt002_in_air: seas2
-      mass_fraction_of_sea_salt003_in_air: seas3
-      mass_fraction_of_sea_salt004_in_air: seas4
+      mass_fraction_of_sea_salt001_in_air: seas2
+      mass_fraction_of_sea_salt002_in_air: seas3
+      mass_fraction_of_sea_salt003_in_air: seas4
+      mass_fraction_of_sea_salt004_in_air: seas5
       mass_fraction_of_hydrophobic_black_carbon_in_air: bc1
       mass_fraction_of_hydrophilic_black_carbon_in_air: bc2
       mass_fraction_of_hydrophobic_organic_carbon_in_air: oc1

--- a/model/aero/aero_model_pseudo.yaml.j2
+++ b/model/aero/aero_model_pseudo.yaml.j2
@@ -25,7 +25,6 @@ state variables:
 - mass_fraction_of_sea_salt002_in_air
 - mass_fraction_of_sea_salt003_in_air
 - mass_fraction_of_sea_salt004_in_air
-- mass_fraction_of_sea_salt005_in_air
 field io names:
   air_temperature: T
   air_pressure_thickness: delp
@@ -40,9 +39,8 @@ field io names:
   mass_fraction_of_dust003_in_air: dust3
   mass_fraction_of_dust004_in_air: dust4
   mass_fraction_of_dust005_in_air: dust5
-  mass_fraction_of_sea_salt001_in_air: seas1
-  mass_fraction_of_sea_salt002_in_air: seas2
-  mass_fraction_of_sea_salt003_in_air: seas3
-  mass_fraction_of_sea_salt004_in_air: seas4
-  mass_fraction_of_sea_salt005_in_air: seas5
+  mass_fraction_of_sea_salt001_in_air: seas2
+  mass_fraction_of_sea_salt002_in_air: seas3
+  mass_fraction_of_sea_salt003_in_air: seas4
+  mass_fraction_of_sea_salt004_in_air: seas5
 tstep: {{aero_forecast_timestep}}


### PR DESCRIPTION
This PR corrects sea salt bin mapping between CRTM forward operator and model. 
Sea-salt bins 2–5 instead of bins 1–4 from model should be used to compute hofx, and be updated after DA. This PR updates the sea salt variable names accordingly.