### PR TITLE
Add option to override all filters with a global setting

### DIFF
--- a/test/client_integration/gdas-atmosphere-templates.yaml
+++ b/test/client_integration/gdas-atmosphere-templates.yaml
@@ -96,6 +96,17 @@ atmosphere_final_increment_prefix: "./anl/atminc."
 # ------------------
 observations: all_observations
 
+# JCB level option to replace obs filters
+# ---------------------------------------
+replace_obs_filters:
+  observations:
+    - abi_g16
+  override_filters:
+    - filter: PreQC
+      maxvalue: 1.0
+      action:
+        name: reject
+
 crtm_coefficient_path: "DATA/crtm/"
 
 # Naming conventions for observational files


### PR DESCRIPTION
The companion PR to https://github.com/NOAA-EMC/jcb/pull/31 offering an example of how to apply the change to just the GOES-16 ABI YAML.