### PR TITLE
Add select hydrometeors to atmospheric DA yamls

### DIFF
--- a/algorithm/atmosphere/atm_addincrement.yaml.j2
+++ b/algorithm/atmosphere/atm_addincrement.yaml.j2
@@ -30,6 +30,9 @@ state:
   - water_vapor_mixing_ratio_wrt_moist_air
   - cloud_liquid_ice
   - cloud_liquid_water
+  - snow_water
+  - rain_water
+  - graupel
   - ozone_mass_mixing_ratio
   - air_pressure_thickness
   - layer_thickness
@@ -40,6 +43,9 @@ state:
     water_vapor_mixing_ratio_wrt_moist_air: spfh
     cloud_liquid_ice: icmr
     cloud_liquid_water: clwmr
+    snow_water: snmr
+    rain_water: rwmr
+    graupel: grle
     ozone_mass_mixing_ratio: o3mr
     air_pressure_thickness: dpres
     layer_thickness: delz
@@ -55,6 +61,9 @@ increment:
   - water_vapor_mixing_ratio_wrt_moist_air
   - cloud_liquid_ice
   - cloud_liquid_water
+  - snow_water
+  - rain_water
+  - graupel
   - ozone_mass_mixing_ratio
   - air_pressure_thickness
   - layer_thickness
@@ -65,6 +74,9 @@ increment:
     water_vapor_mixing_ratio_wrt_moist_air: sphum_inc
     cloud_liquid_ice: icmr_inc
     cloud_liquid_water: liq_wat_inc
+    snow_water: snmr_inc
+    rain_water: rwmr_inc
+    graupel: grle_inc
     ozone_mass_mixing_ratio: o3mr_inc
     air_pressure_thickness: delp_inc
     layer_thickness: delz_inc
@@ -83,6 +95,9 @@ output:
     water_vapor_mixing_ratio_wrt_moist_air: spfh
     cloud_liquid_ice: icmr
     cloud_liquid_water: clwmr
+    snow_water: snmr
+    rain_water: rwmr
+    graupel: grle
     ozone_mass_mixing_ratio: o3mr
     air_pressure_thickness: dpres
     layer_thickness: delz

--- a/algorithm/atmosphere/fv3jedi_correction_increment.yaml.j2
+++ b/algorithm/atmosphere/fv3jedi_correction_increment.yaml.j2
@@ -89,6 +89,9 @@ forecast hours:
       water_vapor_mixing_ratio_wrt_moist_air: sphum_inc
       cloud_liquid_ice: icmr_inc
       cloud_liquid_water: liq_wat_inc
+      snow_water: snmr_inc
+      rain_water: rwmr_inc
+      graupel: grle_inc
       ozone_mass_mixing_ratio: o3mr_inc
       air_pressure_thickness: delp_inc
       layer_thickness: delz_inc
@@ -109,6 +112,9 @@ forecast hours:
       water_vapor_mixing_ratio_wrt_moist_air: sphum_inc
       cloud_liquid_ice: icmr_inc
       cloud_liquid_water: liq_wat_inc
+      snow_water: snmr_inc
+      rain_water: rwmr_inc
+      graupel: grle_inc
       ozone_mass_mixing_ratio: o3mr_inc
       air_pressure_thickness: delp_inc
       layer_thickness: delz_inc

--- a/algorithm/atmosphere/fv3jedi_correction_increment.yaml.j2
+++ b/algorithm/atmosphere/fv3jedi_correction_increment.yaml.j2
@@ -3,6 +3,9 @@ increment variables:
 - layer_thickness
 - air_pressure_thickness
 - cloud_liquid_ice
+- snow_water
+- rain_water
+- graupel
 - ozone_mass_mixing_ratio
 - water_vapor_mixing_ratio_wrt_moist_air
 - air_temperature
@@ -68,6 +71,9 @@ forecast hours:
       water_vapor_mixing_ratio_wrt_moist_air: spfh
       cloud_liquid_ice: icmr
       cloud_liquid_water: clwmr
+      snow_water: snmr
+      rain_water: rwmr
+      graupel: grle
       ozone_mass_mixing_ratio: o3mr
       air_pressure_thickness: dpres
       layer_thickness: delz

--- a/algorithm/atmosphere/fv3jedi_ensemble_recenter.yaml.j2
+++ b/algorithm/atmosphere/fv3jedi_ensemble_recenter.yaml.j2
@@ -32,6 +32,9 @@ members:
     - water_vapor_mixing_ratio_wrt_moist_air
     - cloud_liquid_ice
     - cloud_liquid_water
+    - snow_water
+    - rain_water
+    - graupel
     - ozone_mass_mixing_ratio
     - air_pressure_thickness
     - layer_thickness
@@ -42,6 +45,9 @@ members:
       water_vapor_mixing_ratio_wrt_moist_air: sphum_inc
       cloud_liquid_ice: icmr_inc
       cloud_liquid_water: liq_wat_inc
+      snow_water: snmr_inc
+      rain_water: rwmr_inc
+      graupel: grle_inc
       ozone_mass_mixing_ratio: o3mr_inc
       air_pressure_thickness: delp_inc
       layer_thickness: delz_inc
@@ -58,6 +64,9 @@ members:
     - water_vapor_mixing_ratio_wrt_moist_air
     - cloud_liquid_ice
     - cloud_liquid_water
+    - snow_water
+    - rain_water
+    - graupel
     - ozone_mass_mixing_ratio
     - air_pressure_thickness
     - layer_thickness
@@ -68,6 +77,9 @@ members:
       water_vapor_mixing_ratio_wrt_moist_air: sphum_inc
       cloud_liquid_ice: icmr_inc
       cloud_liquid_water: liq_wat_inc
+      snow_water: snmr_inc
+      rain_water: rwmr_inc
+      graupel: grle_inc
       ozone_mass_mixing_ratio: o3mr_inc
       air_pressure_thickness: delp_inc
       layer_thickness: delz_inc
@@ -87,6 +99,9 @@ members:
       water_vapor_mixing_ratio_wrt_moist_air: sphum_inc
       cloud_liquid_ice: icmr_inc
       cloud_liquid_water: liq_wat_inc
+      snow_water: snmr_inc
+      rain_water: rwmr_inc
+      graupel: grle_inc
       ozone_mass_mixing_ratio: o3mr_inc
       air_pressure_thickness: delp_inc
       layer_thickness: delz_inc

--- a/algorithm/atmosphere/fv3jedi_fv3inc_lgetkf.yaml.j2
+++ b/algorithm/atmosphere/fv3jedi_fv3inc_lgetkf.yaml.j2
@@ -8,6 +8,9 @@ variable change:
   - water_vapor_mixing_ratio_wrt_moist_air
   - cloud_liquid_ice
   - cloud_liquid_water
+  - snow_water
+  - rain_water
+  - graupel
   - ozone_mass_mixing_ratio
   - geopotential_height_at_surface
   output variables: &fv3incrvars
@@ -17,6 +20,9 @@ variable change:
   - water_vapor_mixing_ratio_wrt_moist_air
   - cloud_liquid_ice
   - cloud_liquid_water
+  - snow_water
+  - rain_water
+  - graupel
   - ozone_mass_mixing_ratio
   - air_pressure_thickness
   - layer_thickness
@@ -28,6 +34,9 @@ jedi increment variables:
 - water_vapor_mixing_ratio_wrt_moist_air
 - cloud_liquid_ice
 - cloud_liquid_water
+- snow_water
+- rain_water
+- graupel
 - ozone_mass_mixing_ratio
 fv3 increment variables: *fv3incrvars
 background geometry:
@@ -85,6 +94,9 @@ members from template:
         water_vapor_mixing_ratio_wrt_moist_air: spfh
         cloud_liquid_ice: icmr
         cloud_liquid_water: clwmr
+        snow_water: snmr
+        rain_water: rwmr
+        graupel: grle
         ozone_mass_mixing_ratio: o3mr
         geopotential_height_at_surface: hgtsfc
     jedi increment input:
@@ -106,6 +118,9 @@ members from template:
         cloud_liquid_water: liq_wat_inc
         ozone_mass_mixing_ratio: o3mr_inc
         cloud_liquid_ice: icmr_inc
+        snow_water: snmr_inc
+        rain_water: rwmr_inc
+        graupel: grle_inc
         air_pressure_thickness: delp_inc
         layer_thickness: delz_inc
   pattern: '%mem%'

--- a/algorithm/atmosphere/fv3jedi_fv3inc_variational.yaml.j2
+++ b/algorithm/atmosphere/fv3jedi_fv3inc_variational.yaml.j2
@@ -9,6 +9,9 @@ variable change:
   - cloud_liquid_ice
   - cloud_liquid_water
   - ozone_mass_mixing_ratio
+  - snow_water
+  - rain_water
+  - graupel
   - geopotential_height_at_surface
   output variables: &fv3incrvars
   - eastward_wind
@@ -17,6 +20,9 @@ variable change:
   - water_vapor_mixing_ratio_wrt_moist_air
   - cloud_liquid_ice
   - cloud_liquid_water
+  - snow_water
+  - rain_water
+  - graupel
   - ozone_mass_mixing_ratio
   - air_pressure_thickness
   - layer_thickness
@@ -28,6 +34,9 @@ jedi increment variables:
 - water_vapor_mixing_ratio_wrt_moist_air
 - cloud_liquid_ice
 - cloud_liquid_water
+- snow_water
+- rain_water
+- graupel
 - ozone_mass_mixing_ratio
 fv3 increment variables: *fv3incrvars
 background geometry:
@@ -84,6 +93,9 @@ members:
       water_vapor_mixing_ratio_wrt_moist_air: spfh
       cloud_liquid_ice: icmr
       cloud_liquid_water: clwmr
+      snow_water: snmr
+      rain_water: rwmr
+      graupel: grle
       ozone_mass_mixing_ratio: o3mr
       geopotential_height_at_surface: hgtsfc
   jedi increment input:
@@ -111,6 +123,9 @@ members:
       cloud_liquid_water: liq_wat_inc
       ozone_mass_mixing_ratio: o3mr_inc
       cloud_liquid_ice: icmr_inc
+      snow_water: snmr_inc
+      rain_water: rwmr_inc
+      graupel: grle_inc
       air_pressure_thickness: delp_inc
       layer_thickness: delz_inc
 # Optionally test the application

--- a/model/atmosphere/atmosphere_background_error_hybrid_gsibec_bump.yaml.j2
+++ b/model/atmosphere/atmosphere_background_error_hybrid_gsibec_bump.yaml.j2
@@ -29,7 +29,7 @@ components:
         local interpolator type: oops unstructured grid interpolator
       state variables to inverse: [eastward_wind,northward_wind,air_temperature,air_pressure_at_surface,
                                    water_vapor_mixing_ratio_wrt_moist_air,cloud_liquid_ice,cloud_liquid_water,
-                                   ozone_mass_mixing_ratio]
+                                   snow_water,rain_water,graupel,ozone_mass_mixing_ratio]
     linear variable change:
       linear variable change name: Control2Analysis
       input variables:
@@ -40,6 +40,9 @@ components:
       - water_vapor_mixing_ratio_wrt_moist_air
       - cloud_liquid_ice
       - cloud_liquid_water
+      - snow_water
+      - rain_water
+      - graupel
       - mole_fraction_of_ozone_in_air
       output variables:
       - eastward_wind
@@ -49,6 +52,9 @@ components:
       - water_vapor_mixing_ratio_wrt_moist_air
       - cloud_liquid_ice
       - cloud_liquid_water
+      - snow_water
+      - rain_water
+      - graupel
       - ozone_mass_mixing_ratio
   weight:
     value: 0.125
@@ -67,6 +73,9 @@ components:
         - water_vapor_mixing_ratio_wrt_moist_air
         - cloud_liquid_ice
         - cloud_liquid_water
+        - snow_water
+        - rain_water
+        - graupel
         - ozone_mass_mixing_ratio
         field io names:
           eastward_wind: ugrd
@@ -76,6 +85,9 @@ components:
           water_vapor_mixing_ratio_wrt_moist_air: spfh
           cloud_liquid_ice: icmr
           cloud_liquid_water: clwmr
+          snow_water: snmr
+          rain_water: rwmr
+          graupel: grle
           ozone_mass_mixing_ratio: o3mr
         datapath: {{ atmosphere_background_ensemble_path }}
         filename is datetime templated: true
@@ -98,6 +110,9 @@ components:
         - water_vapor_mixing_ratio_wrt_moist_air
         - cloud_liquid_ice
         - cloud_liquid_water
+        - snow_water
+        - rain_water
+        - graupel
         - ozone_mass_mixing_ratio
         read:
           general:
@@ -255,6 +270,9 @@ components:
       - water_vapor_mixing_ratio_wrt_moist_air
       - cloud_liquid_ice
       - cloud_liquid_water
+      - snow_water
+      - rain_water
+      - graupel
       - ozone_mass_mixing_ratio
       output variables:
       - eastward_wind
@@ -264,6 +282,9 @@ components:
       - water_vapor_mixing_ratio_wrt_moist_air
       - cloud_liquid_ice
       - cloud_liquid_water
+      - snow_water
+      - rain_water
+      - graupel
       - ozone_mass_mixing_ratio
   weight:
     value: 0.875

--- a/model/atmosphere/atmosphere_final_increment_cubed_sphere.yaml.j2
+++ b/model/atmosphere/atmosphere_final_increment_cubed_sphere.yaml.j2
@@ -11,6 +11,9 @@ output:
     - water_vapor_mixing_ratio_wrt_moist_air
     - cloud_liquid_ice
     - cloud_liquid_water
+    - snow_water
+    - rain_water
+    - graupel
     - ozone_mass_mixing_ratio
     field io names:
       eastward_wind: ugrd
@@ -20,6 +23,9 @@ output:
       water_vapor_mixing_ratio_wrt_moist_air: spfh
       cloud_liquid_ice: icmr
       cloud_liquid_water: clwmr
+      snow_water: snmr
+      rain_water: rwmr
+      graupel: grle
       ozone_mass_mixing_ratio: o3mr
 geometry:
   fms initialization:

--- a/model/atmosphere/atmosphere_output_ensemble_increments_cubed_sphere.yaml.j2
+++ b/model/atmosphere/atmosphere_output_ensemble_increments_cubed_sphere.yaml.j2
@@ -9,4 +9,7 @@ field io names:
     water_vapor_mixing_ratio_wrt_moist_air: spfh
     cloud_liquid_ice: icmr
     cloud_liquid_water: clwmr
+    snow_water: snmr
+    rain_water: rwmr
+    graupel: grle
     ozone_mass_mixing_ratio: o3mr

--- a/observations/atmosphere/atms_n20.yaml.j2
+++ b/observations/atmosphere/atms_n20.yaml.j2
@@ -33,6 +33,8 @@
       Sensor_ID: &{{observation_from_jcb}}_sensor_id atms_n20
       EndianType: little_endian
       CoefficientPath: "{{crtm_coefficient_path}}"
+    do fov average: true
+    fov sample points per semimajor axis: 4
     linear obs operator:
       Absorbers: [H2O, O3]
 


### PR DESCRIPTION
This PR adds `snow_water`, `rain_water`, and `graupel` to atmospheric DA yamls.   An additional change is to turn on fov averaging for atms_n20 in `observations/atmosphere/atms_n20.yaml.j2`.

Resolves #215