### PR TITLE
Modify the GHCN obs path for snow DA

### DIFF
--- a/observations/snow/ghcn_snow.yaml.j2
+++ b/observations/snow/ghcn_snow.yaml.j2
@@ -7,7 +7,7 @@
     obsdatain:
       engine:
         type: H5File
-        obsfile: "{{snow_obsdatain_path}}/{{snow_obsdatain_prefix}}{{observation_from_jcb}}.nc"
+        obsfile: "{{snow_prepobs_path}}/{{snow_obsdatain_prefix}}{{observation_from_jcb}}.nc"
         missing file action: warn
     obsdataout:
       engine:


### PR DESCRIPTION
Modify the GHCN obs path to use the data from the `prep` subdirectory under the running directory. 

This PR contributes to https://github.com/NOAA-EMC/GDASApp/pull/2019