### PR TITLE
Change the suffix to the input IMS data

### DIFF
--- a/algorithm/snow/snow_ims_scf_preprocess.yaml.j2
+++ b/algorithm/snow/snow_ims_scf_preprocess.yaml.j2
@@ -24,7 +24,7 @@ geometry:
       filename_orog: '{{ snow_orog_prefix }}_oro_data.nc'
 date: '{{ snow_background_time_iso }}'
 output ioda file: '{{snow_obsdatain_path}}/{{snow_obsdatain_prefix}}ims_snow.tm00.nc'
-input scf file: './obs/ims{{ snow_background_time_julian }}_4km_v1.3.asc'
+input scf file: './obs/ims{{ snow_background_time_julian }}_4km_v1.3.dat'
 mapping file: './obs/IMS4km_to_FV3_mapping.{{ snow_orog_prefix }}_oro_data.nc'
 variables:
 - totalSnowDepth

--- a/algorithm/snow/snow_ims_scf_preprocess.yaml.j2
+++ b/algorithm/snow/snow_ims_scf_preprocess.yaml.j2
@@ -24,7 +24,7 @@ geometry:
       filename_orog: '{{ snow_orog_prefix }}_oro_data.nc'
 date: '{{ snow_background_time_iso }}'
 output ioda file: '{{snow_obsdatain_path}}/{{snow_obsdatain_prefix}}ims_snow.tm00.nc'
-input scf file: './obs/ims{{ snow_background_time_julian }}_4km_v1.3.dat'
+input scf file: './obs/ims{{ snow_background_time_julian }}_4km_v1.3.{{ ims_scf_obs_suffix }}'
 mapping file: './obs/IMS4km_to_FV3_mapping.{{ snow_orog_prefix }}_oro_data.nc'
 variables:
 - totalSnowDepth


### PR DESCRIPTION
Update the input file suffixes from `.asc` to `.dat`, including those for ASCII and NetCDF formats.

Contributes to https://github.com/NOAA-EMC/GDASApp/pull/2023