### PR TITLE
Add some more conventional plus one radiance IODA-stats templates for GSI ncdiags

### DIFF
--- a/observation_statistics/atmosphere_gsi/aircraft_gsi.yaml.j2
+++ b/observation_statistics/atmosphere_gsi/aircraft_gsi.yaml.j2
@@ -1,0 +1,54 @@
+- obs space:
+    name: aircraft_gsi
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{ atmosphere_gsi_obsdatain_path }}/{{ atmosphere_gsi_obsdatain_prefix }}{{ observation_from_jcb }}{{ atmosphere_gsi_obsdatain_suffix }}"
+    simulated variables: ['airTemperature', 'specificHumidity', 'windEastward', 'windNorthward']
+    observed variables: ['airTemperature', 'specificHumidity', 'windEastward', 'windNorthward']
+  statistics to compute: ['mean', 'count', 'RMS']
+  variables: ['airTemperature', 'specificHumidity', 'windEastward', 'windNorthward']
+  groups to process: ['ombg', 'oman']
+  qc groups: ['GsiEffectiveQCGes', 'GsiEffectiveQCAnl']
+  output file: "{{ atmosphere_gsi_obsdataout_path }}/{{ atmosphere_gsi_obsdataout_prefix }}{{ observation_from_jcb }}{{ atmosphere_gsi_obsdataout_suffix }}"
+  output ascii file: "{{ atmosphere_gsi_obsdataout_path }}/{{ observation_from_jcb }}_ioda_stats.txt"
+  ascii vertical bins:
+    vertical bin names: [1000+, 1000-900, 900-800, 800-600, 600-400, 400-300, 300-250, 250-200, 200-150, 150-100, 100-50]
+    vertical bin ranges: [100000, 90000, 80000, 60000, 40000, 30000, 25000, 20000, 15000, 10000, 5000]
+    vertical bin variable: pressure
+  regular grid binning:
+    bin size in degrees: 2.5
+    use negative longitudes: true 
+  domains to process:
+  - domain:
+      name: "SH"
+      first mask variable: latitude
+      first mask range: [-90,0]
+  - domain:
+      name: "NH"
+      first mask variable: latitude
+      first mask range: [0,90]
+  - domain:
+      name: "CONUS"
+      first mask variable: latitude
+      first mask range: [25,49]
+      second mask variable: longitude
+      second mask range: [-125,-66]
+  - domain:
+      name: "Europe"
+      first mask variable: latitude
+      first mask range: [35,70]
+      second mask variable: longitude
+      second mask range: [-11,38]
+  - domain:
+      name: "Africa"
+      first mask variable: latitude
+      first mask range: [-35,37]
+      second mask variable: longitude
+      second mask range: [-17,52]
+  - domain:
+      name: "Asia"
+      first mask variable: latitude
+      first mask range: [0,70]
+      second mask variable: longitude
+      second mask range: [38, 180]

--- a/observation_statistics/atmosphere_gsi/atms_n20_gsi.yaml.j2
+++ b/observation_statistics/atmosphere_gsi/atms_n20_gsi.yaml.j2
@@ -1,0 +1,51 @@
+- obs space:
+    name: atms_n20_gsi
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{ atmosphere_gsi_obsdatain_path }}/{{ atmosphere_gsi_obsdatain_prefix }}{{ observation_from_jcb }}{{ atmosphere_gsi_obsdatain_suffix }}"
+    simulated variables: ['brightnessTemperature']
+    observed variables: ['brightnessTemperature']
+  statistics to compute: ['count', 'mean', 'RMS']
+  variables: ['brightnessTemperature']
+  channels: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22]
+  groups to process: ['ombg', 'oman']
+  qc groups: ['GsiEffectiveQCGes', 'GsiEffectiveQCAnl']
+  output file: "{{ atmosphere_gsi_obsdataout_path }}/{{ atmosphere_gsi_obsdataout_prefix }}{{ observation_from_jcb }}{{ atmosphere_gsi_obsdataout_suffix }}"
+  output ascii file: "{{ atmosphere_gsi_obsdataout_path }}/{{ observation_from_jcb }}_ioda_stats.txt"
+  regular grid binning:
+    bin size in degrees: 2.5
+    use negative longitudes: true 
+  domains to process:
+    - domain:
+        name: "SH"
+        first mask variable: latitude
+        first mask range: [-90,0]
+    - domain:
+        name: "NH"
+        first mask variable: latitude
+        first mask range: [0,90]
+    - domain:
+        name: "CONUS"
+        first mask variable: latitude
+        first mask range: [25,49]
+        second mask variable: longitude
+        second mask range: [-125,-66]
+    - domain:
+        name: "Europe"
+        first mask variable: latitude
+        first mask range: [35,70]
+        second mask variable: longitude
+        second mask range: [-11,38]
+    - domain:
+        name: "Africa"
+        first mask variable: latitude
+        first mask range: [-35,37]
+        second mask variable: longitude
+        second mask range: [-17,52]
+    - domain:
+        name: "Asia"
+        first mask variable: latitude
+        first mask range: [0,70]
+        second mask variable: longitude
+        second mask range: [38, 180]

--- a/observation_statistics/atmosphere_gsi/sfc_gsi.yaml.j2
+++ b/observation_statistics/atmosphere_gsi/sfc_gsi.yaml.j2
@@ -1,13 +1,13 @@
 - obs space:
-    name: sfc_ps_gsi
+    name: sfc_gsi
     obsdatain:
       engine:
         type: H5File
         obsfile: "{{ atmosphere_gsi_obsdatain_path }}/{{ atmosphere_gsi_obsdatain_prefix }}{{ observation_from_jcb }}{{ atmosphere_gsi_obsdatain_suffix }}"
-    simulated variables: ['stationPressure']
-    observed variables: ['stationPressure']
+    simulated variables: ['stationPressure', 'airTemperature', 'specificHumidity', 'windEastward', 'windNorthward']
+    observed variables: ['stationPressure', 'airTemperature', 'specificHumidity', 'windEastward', 'windNorthward']
   statistics to compute: ['mean', 'count', 'RMS']
-  variables: ['stationPressure']
+  variables: ['stationPressure', 'airTemperature', 'specificHumidity', 'windEastward', 'windNorthward']
   groups to process: ['ombg', 'oman']
   qc groups: ['GsiEffectiveQCGes', 'GsiEffectiveQCAnl']
   output file: "{{ atmosphere_gsi_obsdataout_path }}/{{ atmosphere_gsi_obsdataout_prefix }}{{ observation_from_jcb }}{{ atmosphere_gsi_obsdataout_suffix }}"

--- a/observation_statistics/atmosphere_gsi/sfc_ps_gsi.yaml.j2
+++ b/observation_statistics/atmosphere_gsi/sfc_ps_gsi.yaml.j2
@@ -1,5 +1,5 @@
 - obs space:
-    name: gsi_sfc_ps
+    name: sfc_ps_gsi
     obsdatain:
       engine:
         type: H5File

--- a/observation_statistics/atmosphere_gsi/sfcship_gsi.yaml.j2
+++ b/observation_statistics/atmosphere_gsi/sfcship_gsi.yaml.j2
@@ -1,0 +1,54 @@
+- obs space:
+    name: sfcship_gsi
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{ atmosphere_gsi_obsdatain_path }}/{{ atmosphere_gsi_obsdatain_prefix }}{{ observation_from_jcb }}{{ atmosphere_gsi_obsdatain_suffix }}"
+    simulated variables: ['stationPressure', 'airTemperature', 'virtualTemperature', 'specificHumidity', 'windEastward', 'windNorthward']
+    observed variables: ['stationPressure', 'airTemperature', 'virtualTemperature', 'specificHumidity', 'windEastward', 'windNorthward']
+  statistics to compute: ['mean', 'count', 'RMS']
+  variables: ['stationPressure', 'airTemperature', 'virtualTemperature', 'specificHumidity', 'windEastward', 'windNorthward']
+  groups to process: ['ombg', 'oman']
+  qc groups: ['GsiEffectiveQCGes', 'GsiEffectiveQCAnl']
+  output file: "{{ atmosphere_gsi_obsdataout_path }}/{{ atmosphere_gsi_obsdataout_prefix }}{{ observation_from_jcb }}{{ atmosphere_gsi_obsdataout_suffix }}"
+  output ascii file: "{{ atmosphere_gsi_obsdataout_path }}/{{ observation_from_jcb }}_ioda_stats.txt"
+  ascii vertical bins:
+    vertical bin names: [1000+, 1000-900, 900-800, 800-600, 600-400, 400-300, 300-250, 250-200, 200-150, 150-100, 100-50]
+    vertical bin ranges: [100000, 90000, 80000, 60000, 40000, 30000, 25000, 20000, 15000, 10000, 5000]
+    vertical bin variable: pressure
+  regular grid binning:
+    bin size in degrees: 2.5
+    use negative longitudes: true 
+  domains to process:
+  - domain:
+      name: "SH"
+      first mask variable: latitude
+      first mask range: [-90,0]
+  - domain:
+      name: "NH"
+      first mask variable: latitude
+      first mask range: [0,90]
+  - domain:
+      name: "CONUS"
+      first mask variable: latitude
+      first mask range: [25,49]
+      second mask variable: longitude
+      second mask range: [-125,-66]
+  - domain:
+      name: "Europe"
+      first mask variable: latitude
+      first mask range: [35,70]
+      second mask variable: longitude
+      second mask range: [-11,38]
+  - domain:
+      name: "Africa"
+      first mask variable: latitude
+      first mask range: [-35,37]
+      second mask variable: longitude
+      second mask range: [-17,52]
+  - domain:
+      name: "Asia"
+      first mask variable: latitude
+      first mask range: [0,70]
+      second mask variable: longitude
+      second mask range: [38, 180]

--- a/observation_statistics/atmosphere_gsi/sondes_gsi.yaml.j2
+++ b/observation_statistics/atmosphere_gsi/sondes_gsi.yaml.j2
@@ -1,0 +1,54 @@
+- obs space:
+    name: sondes_gsi
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{ atmosphere_gsi_obsdatain_path }}/{{ atmosphere_gsi_obsdatain_prefix }}{{ observation_from_jcb }}{{ atmosphere_gsi_obsdatain_suffix }}"
+    simulated variables: ['stationPressure', 'airTemperature', 'virtualTemperature', 'specificHumidity', 'windEastward', 'windNorthward']
+    observed variables: ['stationPressure', 'airTemperature', 'virtualTemperature', 'specificHumidity', 'windEastward', 'windNorthward']
+  statistics to compute: ['mean', 'count', 'RMS']
+  variables: ['stationPressure', 'airTemperature', 'virtualTemperature', 'specificHumidity', 'windEastward', 'windNorthward']
+  groups to process: ['ombg', 'oman']
+  qc groups: ['GsiEffectiveQCGes', 'GsiEffectiveQCAnl']
+  output file: "{{ atmosphere_gsi_obsdataout_path }}/{{ atmosphere_gsi_obsdataout_prefix }}{{ observation_from_jcb }}{{ atmosphere_gsi_obsdataout_suffix }}"
+  output ascii file: "{{ atmosphere_gsi_obsdataout_path }}/{{ observation_from_jcb }}_ioda_stats.txt"
+  ascii vertical bins:
+    vertical bin names: [1000+, 1000-900, 900-800, 800-600, 600-400, 400-300, 300-250, 250-200, 200-150, 150-100, 100-50]
+    vertical bin ranges: [100000, 90000, 80000, 60000, 40000, 30000, 25000, 20000, 15000, 10000, 5000]
+    vertical bin variable: pressure
+  regular grid binning:
+    bin size in degrees: 2.5
+    use negative longitudes: true 
+  domains to process:
+  - domain:
+      name: "SH"
+      first mask variable: latitude
+      first mask range: [-90,0]
+  - domain:
+      name: "NH"
+      first mask variable: latitude
+      first mask range: [0,90]
+  - domain:
+      name: "CONUS"
+      first mask variable: latitude
+      first mask range: [25,49]
+      second mask variable: longitude
+      second mask range: [-125,-66]
+  - domain:
+      name: "Europe"
+      first mask variable: latitude
+      first mask range: [35,70]
+      second mask variable: longitude
+      second mask range: [-11,38]
+  - domain:
+      name: "Africa"
+      first mask variable: latitude
+      first mask range: [-35,37]
+      second mask variable: longitude
+      second mask range: [-17,52]
+  - domain:
+      name: "Asia"
+      first mask variable: latitude
+      first mask range: [0,70]
+      second mask variable: longitude
+      second mask range: [38, 180]


### PR DESCRIPTION
As the title says, we are adding in conventional sfc, sfcship, sondes, and aircraft as well as ATMS N20 templates. The workflow will produce IODA files from GSI nc diags, and then these can be used in the IODA-stats utility to produce summary stats.