### PR TITLE
Make spectralRadiance vs brightnessTemperature an option + some small conventional ob fixes

### DIFF
--- a/observations/atmosphere/radiance_cris-fsr_n20.yaml.j2
+++ b/observations/atmosphere/radiance_cris-fsr_n20.yaml.j2
@@ -15,9 +15,11 @@
         obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"
     io pool:
       max pool size: 1
+{% if rad_to_tb | default(false) %}
     observed variables: [spectralRadiance]
-    simulated variables: [brightnessTemperature]
     derived variables: [brightnessTemperature]
+{% endif %}
+    simulated variables: [brightnessTemperature]
     channels: &{{observation_from_jcb}}_simulated_channels {{ get_satellite_variable(observation_from_jcb, "simulated") }}
 
   # Observation Operator

--- a/observations/atmosphere/radiance_cris-fsr_n21.yaml.j2
+++ b/observations/atmosphere/radiance_cris-fsr_n21.yaml.j2
@@ -15,9 +15,11 @@
         obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"
     io pool:
       max pool size: 1
+{% if rad_to_tb | default(false) %}
     observed variables: [spectralRadiance]
-    simulated variables: [brightnessTemperature]
     derived variables: [brightnessTemperature]
+{% endif %}
+    simulated variables: [brightnessTemperature]
     channels: &{{observation_from_jcb}}_simulated_channels {{ get_satellite_variable(observation_from_jcb, "simulated") }}
 
   # Observation Operator

--- a/observations/atmosphere/radiance_cris-fsr_npp.yaml.j2
+++ b/observations/atmosphere/radiance_cris-fsr_npp.yaml.j2
@@ -15,9 +15,11 @@
         obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"
     io pool:
       max pool size: 1
+{% if rad_to_tb | default(false) %}
     observed variables: [spectralRadiance]
-    simulated variables: [brightnessTemperature]
     derived variables: [brightnessTemperature]
+{% endif %}
+    simulated variables: [brightnessTemperature]
     channels: &{{observation_from_jcb}}_simulated_channels {{ get_satellite_variable(observation_from_jcb, "simulated") }}
 
   # Observation Operator

--- a/observations/atmosphere/radiance_iasi_metop-a.yaml.j2
+++ b/observations/atmosphere/radiance_iasi_metop-a.yaml.j2
@@ -15,9 +15,11 @@
         obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"
     io pool:
       max pool size: 1
+{% if rad_to_tb | default(false) %}
     observed variables: [spectralRadiance]
-    simulated variables: [brightnessTemperature]
     derived variables: [brightnessTemperature]
+{% endif %}
+    simulated variables: [brightnessTemperature]
     channels: &{{observation_from_jcb}}_simulated_channels {{ get_satellite_variable(observation_from_jcb, "simulated") }}
 
   # Observation Operator

--- a/observations/atmosphere/radiance_iasi_metop-b.yaml.j2
+++ b/observations/atmosphere/radiance_iasi_metop-b.yaml.j2
@@ -15,9 +15,11 @@
         obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"
     io pool:
       max pool size: 1
+{% if rad_to_tb | default(false) %}
     observed variables: [spectralRadiance]
-    simulated variables: [brightnessTemperature]
     derived variables: [brightnessTemperature]
+{% endif %}
+    simulated variables: [brightnessTemperature]
     channels: &{{observation_from_jcb}}_simulated_channels {{ get_satellite_variable(observation_from_jcb, "simulated") }}
 
   # Observation Operator

--- a/observations/atmosphere/radiance_iasi_metop-c.yaml.j2
+++ b/observations/atmosphere/radiance_iasi_metop-c.yaml.j2
@@ -15,9 +15,11 @@
         obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"
     io pool:
       max pool size: 1
+{% if rad_to_tb | default(false) %}
     observed variables: [spectralRadiance]
-    simulated variables: [brightnessTemperature]
     derived variables: [brightnessTemperature]
+{% endif %}
+    simulated variables: [brightnessTemperature]
     channels: &{{observation_from_jcb}}_simulated_channels {{ get_satellite_variable(observation_from_jcb, "simulated") }}
 
   # Observation Operator

--- a/observations/atmosphere/satwind.yaml.j2
+++ b/observations/atmosphere/satwind.yaml.j2
@@ -1,0 +1,46 @@
+-
+
+  # Observation Space (I/O)
+  # -----------------------
+  obs space:
+    name: satwind
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdatain_path}}/{{atmosphere_obsdatain_prefix}}{{observation_from_jcb}}{{atmosphere_obsdatain_suffix}}"
+        missing file action: warn
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"
+    io pool:
+      max pool size: 1
+    simulated variables: [windEastward, windNorthward]
+
+  # Observation Operator
+  # --------------------
+  obs operator:
+    name: VertInterp
+    hofx scaling field: SurfaceWindScalingPressure
+    hofx scaling field group: DerivedVariables
+
+  # Linear Observation Operator
+  # ---------------------------
+  linear obs operator:
+    name: VertInterp
+
+  # Observation Prior Filters (QC)
+  # ------------------------------
+  obs prior filters:
+  # Apply variable changes needed for wind scaling
+  # For wind observations with pressure provided
+  - filter: Variable Transforms
+    Transform: SurfaceWindScalingPressure
+    SkipWhenNoObs: false
+
+  - filter: PreQC
+    maxvalue: 0.0
+    minvalue: 0.0
+    inputQC: GsiEffectiveQCGes
+    action:
+      name: reject

--- a/observations/atmosphere/sfc.yaml.j2
+++ b/observations/atmosphere/sfc.yaml.j2
@@ -21,8 +21,11 @@
   # --------------------
   obs operator:
     name: SfcCorrected
+    variables:
+    - name: stationPressure
     correction scheme to use: GSL
-    geovar_sfc_geomz: surface_geometric_height
+    station_altitude: height
+    geovar_sfc_geomz: height_above_mean_sea_level_at_surface
     geovar_geomz: geopotential_height
 
   # Linear Observation Operator

--- a/observations/atmosphere/sfcship.yaml.j2
+++ b/observations/atmosphere/sfcship.yaml.j2
@@ -31,7 +31,7 @@
       variables:
       - name: stationPressure
       correction scheme to use: GSL
-      geovar_sfc_geomz: surface_geometric_height
+      geovar_sfc_geomz: height_above_mean_sea_level_at_surface
       geovar_geomz: geopotential_height
 
   # Linear Observation Operator

--- a/observations/atmosphere/sondes.yaml.j2
+++ b/observations/atmosphere/sondes.yaml.j2
@@ -19,7 +19,7 @@
         obsfile: "{{atmosphere_obsdataout_path}}/{{atmosphere_obsdataout_prefix}}{{observation_from_jcb}}{{atmosphere_obsdataout_suffix}}"
     io pool:
       max pool size: 1
-    simulated variables: [stationPressure, airTemperature, windEastward, windNorthward,
+    simulated variables: [stationPressure, airTemperature, virtualTemperature, windEastward, windNorthward,
       specificHumidity]
 
   # Observation Operator
@@ -30,6 +30,7 @@
     - name: VertInterp
       variables:
       - name: airTemperature
+      - name: virtualTemperature
       - name: windEastward
       - name: windNorthward
       - name: specificHumidity
@@ -48,6 +49,7 @@
     - name: VertInterp
       variables:
       - name: airTemperature
+      - name: virtualTemperature
       - name: windEastward
       - name: windNorthward
       - name: specificHumidity


### PR DESCRIPTION
Add an option (default is brightnessTemperature) to use either brightnessTemperature or spectralRadiance for CrIS and IASI. Also some minor fixes for sfc, sfcship, and sondes, as well as a simple satwind YAML to use GSI ncdiag obs.